### PR TITLE
docs(session-close): Phase 3b exit — Slice 7 cos-sim validation PASS

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ citing phase progress in prose elsewhere — it drifts.
 | **Phase 1** | Bazel monorepo, proto contracts, C++ engine + whisper.cpp + StreamTranscribe, Go Gateway skeleton, Vite/React frontend with provider abstractions | ✅ Done |
 | **Phase 2** | Internal MVP, BFF wiring, WebRTC, WER golden-audio regression | 🚧 A1–A5 shipped; a few items deliberately descoped — see [Known Gaps](#known-gaps-phase-2) below |
 | **Phase 3a** | Platform foundations (hermetic Node via `aspect_rules_js`, Opus-on-engine, gateway N:N topology, RAG corpus pipeline, engine-owned inference) | ✅ Done |
-| **Phase 3b** | Engine RAG inference: shared ggml runtime, GGMLEmbedder (bge-m3), Qdrant C++ client, `engine seed` subcommand, cloud-cache strategy (ADR-0014 β/δ) | 🚧 Slices 1–6 landed; validation experiment (Slice 7, FP16 cos-sim ≥ 0.95) pending |
+| **Phase 3b** | Engine RAG inference: shared ggml runtime, GGMLEmbedder (bge-m3), Qdrant C++ client, `engine seed` subcommand, cloud-cache strategy (ADR-0014 β/δ) | ✅ Done — all seven slices landed; Slice 7 validation PASS (mean cos-sim 0.9659 vs FP reference, threshold 0.95) |
 | **Phase 3c** | Pure-web host + viewer UIs (React + Vite) | 📋 Designed; gated on Phase 3b |
 | **Phase 4** | Packaging (OCI, Cosign, SLSA L3), progressive delivery, observability | 📋 Designed |
 | **Phase 5** | External pentest, compliance audit, Tauri shell | 📋 Designed |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # 🗺️ Aegis Core (V2) — Roadmap
 
 **Current Status**: Architecture design complete; implementation bootstrapping pending.
-**Last Updated**: 2026-04-17 (Slice 6 landed)
+**Last Updated**: 2026-04-17 (Phase 3b exited — Slice 7 cos-sim validation PASS, mean 0.9659)
 
 This roadmap reflects the architectural decisions captured in
 `ARCHITECTURE.md` and the ADRs in `docs/adr/`. Before working on any
@@ -262,7 +262,7 @@ Driven by ADR-0020. Out-of-3b exit criterion: `engine --seed --corpus docs/rag/t
 - [x] **ggml triple bump** to v0.9.9 to unblock llama.cpp b8595's `gguf_*_ptr` symbols (incident-10 resolution) — Slice 4
 - [x] Qdrant C++ client wired — Slice 5 (`dfadf5d`). Direct gRPC stubs generated from Qdrant v1.17.1 protos checked in at `proto/qdrant/v1.17.1/` (see `PROVENANCE.md` for the http_archive-vs-checked-in trade-off per incident-11). Surface is scoped to `CreateCollection` / `UpsertPoints` / `Search` — full API wrapper is YAGNI until a caller needs more.
 - [x] `engine seed --corpus PATH --target={local|cloud}` subcommand in `engine_cpp/cmd/engine/` — Slice 6 (`a0e32be`). Subcommand dispatch (not flag-mode) per 2026-04-17 design decision; content-hash UUID-5-style point IDs via SHA-256; `aegis_<stem>` collection naming; payload = `{text, source_path, chunk_index}`; cloud target reads `QDRANT_URL` + `QDRANT_API_KEY` from env. Verified end-to-end against Taiwan corpus + local Qdrant v1.17.1: 10 chunks → `aegis_taiwan` collection, idempotent re-run. Multi-tenancy payload extension deferred to Phase 4 Cognito wiring (ADR-0022).
-- [ ] **Validation experiment**: load the Taiwan corpus via FlagEmbedding reference (scratch Python, not committed) + `GGMLEmbedder`; assert mean cos-sim ≥ 0.95 across all chunks. Scratch Python deleted after validation.
+- [x] **Validation experiment (Slice 7)**: Taiwan corpus through `engine seed` into Qdrant, then scratch Python (`sentence-transformers` with `BAAI/bge-m3` FP reference, `qdrant-client` pulling the Q4_K_M vectors back out) compared per-chunk cosine similarity. **Result 2026-04-17**: N=10, **mean=0.9659**, median=0.9654, min=0.9591, max=0.9742 — all chunks individually above the 0.95 threshold, mean passes with ~1.6% margin. Phase 3b exit criterion met; no need to upgrade Q4_K_M → Q8_0 or revisit chunker params. Scratch script + `.venv` deleted post-validation per the scratch-Python-tool-tier discipline (ADR-0020 / `feedback_inference` memory).
 - [x] **ADR-0010 revision**: split `ResourceBudget` into `ModelBudget` (process-global, ~500 MB for whisper + bge-m3 Q4_K_M) and `SessionBudget` (per-session, existing `kDefaultReservationBytes`). ADR updated in Slice 1 (`e61b192`); code landed in Slice 3.
 - [x] **whisper.cpp deployment-target fix** (incident-09 Prevention follow-up): mirror what libopus did in commit `51835b1` — add `CMAKE_OSX_DEPLOYMENT_TARGET=11.0` to `whisper_cpp.BUILD` cache_entries, silencing the ~18 libggml-cpu warnings on the engine link — Slice 1 (`0d2bdb8`).
 

--- a/docs/interview-notes.md
+++ b/docs/interview-notes.md
@@ -59,6 +59,9 @@ gets stored where.
 2. A real microphone recording goes in; a real transcript comes out.
 3. The automated test suite proves it end-to-end against a reference
    audio clip.
+4. A text corpus goes in via `engine seed`; the retrieved embeddings
+   are within a validated margin of the floating-point reference, so
+   retrieval quality is quantified, not asserted.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 3b Slice 7 validation experiment — the final piece closing
Phase 3b — ran today (2026-04-17).

### The experiment

Scratch Python, one-shot, not committed per ADR-0020 + the
`feedback_inference` memory's "Python stays at the tool tier"
rule:

1. `engine seed --corpus docs/rag/taiwan.md --target=local` populates
   local Qdrant with Q4_K_M bge-m3 embeddings (10 chunks, 1024-d
   cosine-normalized).
2. A scratch Python script (`sentence-transformers` with
   `BAAI/bge-m3` upstream reference + `qdrant-client` + `numpy`)
   pulls the Q4_K_M vectors out of Qdrant by content-hash UUID, re-
   embeds the same chunk texts at floating-point precision, and
   computes per-chunk cosine similarity.
3. Script + `.venv` + bundled transformer deps deleted post-run.

### The result

| Statistic | Value |
|---|---|
| N chunks | 10 |
| mean cos-sim | **0.9659** |
| median | 0.9654 |
| min | 0.9591 |
| max | 0.9742 |
| threshold | 0.95 |
| verdict | **PASS** (mean ≥ threshold with ~1.6 % margin; all 10 chunks individually above threshold) |

Q4_K_M bge-m3 semantic fidelity is sufficient for the Phase 3b RAG
use case. No need to upgrade Q4_K_M → Q8_0 (635 MB) or revisit
chunker defaults.

### Docs touched

- `ROADMAP.md` — Slice 7 ticked with result numbers inline;
  `Last Updated` bumped to reflect Phase 3b exit.
- `README.md` — Status table Phase 3b flipped from 🚧 to ✅ with
  the mean-cos-sim result cited. No longer labels Slice 7 as
  pending.
- `docs/interview-notes.md` — "What's working today" gets a fourth
  line acknowledging retrieval quality is now quantified rather
  than asserted. Intentionally left abstract (no hardcoded number)
  to avoid the drift pattern we purged from README in PR #17.

### Session-close discipline

Ran both greps per CLAUDE.md Rule 3:

- `grep -rIln "session-close-review:" . --include='*.md'` — 5 hits
  (the four marker-bearing docs + CLAUDE.md documenting the
  pattern). `threat-model` and `incidents` had no session-
  introduced drift (no new external surface; no Rule 7–qualifying
  blocker this session — the FlagEmbedding `is_torch_fx_available`
  import snag was <5 min and resolved by swapping to
  `sentence-transformers`).
- Placeholder-drift grep clean outside immutable ADRs / stable
  `github-setup` / personal `interview-prep` / the rule
  documentation itself.

## What's next (not in this PR)

Phase 3b is done. Next horizon is **Phase 3c (frontend host UI)**
— gated on 3b, now unblocked — or **Phase 4a (OCI packaging)**,
audience-driven pick. Tracking both in
`memory/project_phase3b_handoff.md`.

## Test plan

- [x] Scratch validation ran locally: 10/10 chunks above threshold,
      mean 0.9659
- [x] `bazel build //...` remains green (no code change this PR)
- [ ] CI green across all 6 jobs (verified per CLAUDE.md Rule 1
      full-matrix check after this PR's run lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)