### PR TITLE
Phase 3c Slice 1 — provider scaffolding (FileSystem / Notification / AutoUpdate) + Tauri-compliance gate

### DIFF
--- a/.github/workflows/ci-baseline.yml
+++ b/.github/workflows/ci-baseline.yml
@@ -219,6 +219,24 @@ jobs:
             --test_tag_filters=-requires-model
 
   # ---------------------------------------------------------------------------
+  # ADR-0002 Phase 3 Web Frontend compliance — Tauri-wrap compatibility.
+  # Greps frontend_web/src/ for the six forbidden patterns from ADR-0002's
+  # "Constraints on the Phase 3 Web Frontend" section. Runs in < 1s; fails
+  # the PR if a chrome.* / Service Worker / SharedArrayBuffer / out-of-
+  # provider notification / Blob-download / navigator.mediaDevices slip-
+  # through appears. Protects the Phase 4+ Tauri shell migration path.
+  # ---------------------------------------------------------------------------
+  frontend-tauri-compliance:
+    name: Frontend Tauri-compatibility check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run ADR-0002 Phase 3 compliance grep
+        run: ./tools/scripts/check_frontend_tauri_compliance.sh
+
+  # ---------------------------------------------------------------------------
   # Documentation link check — basic sanity for internal cross-references.
   # Uses a lightweight action; does not fail the build on external link
   # timeouts (those are noisy).

--- a/frontend_web/src/providers/AutoUpdateProvider/WebAutoUpdateProvider.ts
+++ b/frontend_web/src/providers/AutoUpdateProvider/WebAutoUpdateProvider.ts
@@ -1,0 +1,35 @@
+// frontend_web/src/providers/AutoUpdateProvider/WebAutoUpdateProvider.ts
+//
+// Phase 3 web build has no native updater. Browsers ARE the updater:
+// each reload picks up whatever Vite built + whatever headers the CDN
+// served. So this implementation is a deliberate no-op that fails
+// loudly rather than silently when `applyUpdate` is called — the
+// caller probably shouldn't have surfaced an "Install update" button
+// for a web deploy.
+
+import type { AutoUpdateProvider, UpdateCheckResult } from "./types";
+
+export class WebAutoUpdateProvider implements AutoUpdateProvider {
+  async checkForUpdate(): Promise<UpdateCheckResult> {
+    // Web cannot meaningfully compare its own bundle against a
+    // "latest" — the CDN / browser cache has the final say. Report
+    // up-to-date so any boot-time banner logic degrades to "no
+    // banner shown" rather than a false positive.
+    return { kind: "up-to-date" };
+  }
+
+  async applyUpdate(): Promise<void> {
+    // A pure-web caller asking to "apply an update" is a bug — the
+    // browser reload is the mechanism. Throw so a rogue UI path
+    // surfaces in dev rather than silently succeeding.
+    throw new Error(
+      "WebAutoUpdateProvider.applyUpdate: not supported in a web-only " +
+        "build. Trigger a browser reload (location.reload) or switch to " +
+        "a Tauri shell where tauri-plugin-updater implements this path.",
+    );
+  }
+
+  isSupported(): boolean {
+    return false;
+  }
+}

--- a/frontend_web/src/providers/AutoUpdateProvider/index.ts
+++ b/frontend_web/src/providers/AutoUpdateProvider/index.ts
@@ -1,0 +1,19 @@
+// frontend_web/src/providers/AutoUpdateProvider/index.ts
+//
+// Public surface of the AutoUpdateProvider port. Re-exports types
+// and the factory. Phase 4 Tauri wire-up is a one-line change here.
+
+import { WebAutoUpdateProvider } from "./WebAutoUpdateProvider";
+import type { AutoUpdateProvider } from "./types";
+
+export type {
+  AutoUpdateProvider,
+  UpdateCheckResult,
+  UpdateInfo,
+} from "./types";
+
+export { WebAutoUpdateProvider };
+
+export function pickAutoUpdateProvider(): AutoUpdateProvider {
+  return new WebAutoUpdateProvider();
+}

--- a/frontend_web/src/providers/AutoUpdateProvider/types.ts
+++ b/frontend_web/src/providers/AutoUpdateProvider/types.ts
@@ -1,0 +1,66 @@
+// frontend_web/src/providers/AutoUpdateProvider/types.ts
+//
+// ADR-0002 Constraint 5: auto-update behaviour must sit behind a
+// provider interface so the Phase 4+ Tauri shell can plug in Tauri's
+// updater plugin (tauri-plugin-updater) without refactoring the
+// Host UI's "check for updates" affordance.
+//
+// Pure-web builds have no meaningful auto-update — the browser is
+// the delivery mechanism; each reload IS the "update". The Web
+// implementation below therefore always reports "up to date" and
+// `applyUpdate` is a no-op. The interface still exists so future
+// Tauri / PWA-install flows slot in without changing consumer code.
+
+export interface UpdateInfo {
+  /** Semver of the available update (e.g. "0.5.3"). */
+  readonly version: string;
+  /** Optional user-facing changelog summary to show in the UI. */
+  readonly notes?: string;
+  /**
+   * True when applying the update requires restarting the app /
+   * shell. Web apps never need a restart; Tauri bundles do.
+   */
+  readonly requiresRestart: boolean;
+}
+
+export type UpdateCheckResult =
+  | { readonly kind: "up-to-date" }
+  | { readonly kind: "update-available"; readonly info: UpdateInfo }
+  | { readonly kind: "check-failed"; readonly reason: string };
+
+/**
+ * The port. Two callers are expected:
+ *
+ *   - An app-boot probe that decides whether to display an
+ *     "Update available" banner in the header.
+ *   - A user-initiated "Check for updates…" menu item.
+ *
+ * Both paths call `checkForUpdate()` and branch on the result; the
+ * UI never needs to know whether the backing implementation is web,
+ * Tauri, or a future PWA flow.
+ */
+export interface AutoUpdateProvider {
+  /**
+   * Ask the backing mechanism whether a newer version exists.
+   * Resolves with one of the three `UpdateCheckResult` variants.
+   * Web returns `up-to-date` unconditionally (no shell version to
+   * compare against). Tauri queries the configured update endpoint
+   * and surfaces real semver + notes.
+   */
+  checkForUpdate(): Promise<UpdateCheckResult>;
+
+  /**
+   * Begin applying an available update. Rejects when the provider
+   * has no update to apply (e.g. Web, or Tauri after an up-to-date
+   * check). The Tauri implementation downloads + installs + restarts
+   * the app; caller should assume the page will unload mid-call.
+   */
+  applyUpdate(): Promise<void>;
+
+  /**
+   * True when the platform has a real auto-update mechanism. Web is
+   * always false (the browser is the updater). Tauri is true only
+   * when the updater plugin is configured.
+   */
+  isSupported(): boolean;
+}

--- a/frontend_web/src/providers/FileSystemProvider/WebFileSystemProvider.ts
+++ b/frontend_web/src/providers/FileSystemProvider/WebFileSystemProvider.ts
@@ -1,0 +1,55 @@
+// frontend_web/src/providers/FileSystemProvider/WebFileSystemProvider.ts
+//
+// Phase 3 web implementation: Blob + anchor-click download. Works in
+// every target WebView (Chrome, Edge, WKWebView); no `chrome.*`, no
+// File System Access API (WKWebView gap), no Service Worker (ADR-0002
+// Constraint 3). Phase 4 Tauri will replace this with native file
+// dialog + fs::write while keeping the `FileSystemProvider` surface
+// unchanged.
+
+import type {
+  FileExportFormat,
+  FileSystemProvider,
+  SaveAsRequest,
+  SaveAsResult,
+} from "./types";
+
+const MIME_BY_FORMAT: Record<FileExportFormat, string> = {
+  markdown: "text/markdown;charset=utf-8",
+  json: "application/json;charset=utf-8",
+  text: "text/plain;charset=utf-8",
+};
+
+export class WebFileSystemProvider implements FileSystemProvider {
+  async saveAs(req: SaveAsRequest): Promise<SaveAsResult> {
+    const mime = MIME_BY_FORMAT[req.format];
+    const blob = new Blob([req.content], { type: mime });
+    const url = URL.createObjectURL(blob);
+    try {
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = req.suggestedName;
+      // Must be attached to the DOM for Firefox to honor the click —
+      // Chrome and WKWebView tolerate a detached anchor but doing
+      // both costs nothing and avoids a whole class of browser quirk.
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      // See types.ts SaveAsResult docstring: Web cannot observe the
+      // user's response to the browser download prompt. We report
+      // `written` optimistically; the caller's UX should treat this
+      // as "save dispatched" rather than "confirmed on disk".
+      return { kind: "written", finalName: req.suggestedName };
+    } finally {
+      // Release the blob after the click handler has definitely
+      // consumed the URL. A tick is plenty; Chrome documents that
+      // same-task reads complete before revoke takes effect.
+      queueMicrotask(() => URL.revokeObjectURL(url));
+    }
+  }
+
+  isSupported(): boolean {
+    // Blob + anchor-download is universally available in our targets.
+    return typeof document !== "undefined" && typeof Blob !== "undefined";
+  }
+}

--- a/frontend_web/src/providers/FileSystemProvider/index.ts
+++ b/frontend_web/src/providers/FileSystemProvider/index.ts
@@ -1,0 +1,28 @@
+// frontend_web/src/providers/FileSystemProvider/index.ts
+//
+// Public surface of the FileSystemProvider port. Re-exports types and
+// the factory; app code never imports `WebFileSystemProvider`
+// directly so the Phase 4 Tauri swap is a one-line change here.
+
+import { WebFileSystemProvider } from "./WebFileSystemProvider";
+import type { FileSystemProvider } from "./types";
+
+export type {
+  FileExportFormat,
+  FileSystemProvider,
+  SaveAsRequest,
+  SaveAsResult,
+} from "./types";
+
+export { WebFileSystemProvider };
+
+/**
+ * Build the `FileSystemProvider` for the current deploy target.
+ *
+ * Phase 3 web is the only option. When Phase 4 ships the Tauri shell,
+ * this factory gains a `VITE_AEGIS_SHELL` env branch (or detects the
+ * Tauri-injected global) and returns a `TauriFileSystemProvider`.
+ */
+export function pickFileSystemProvider(): FileSystemProvider {
+  return new WebFileSystemProvider();
+}

--- a/frontend_web/src/providers/FileSystemProvider/types.ts
+++ b/frontend_web/src/providers/FileSystemProvider/types.ts
@@ -1,0 +1,74 @@
+// frontend_web/src/providers/FileSystemProvider/types.ts
+//
+// ADR-0002 Constraint 5: filesystem operations must sit behind a
+// provider interface so the Phase 4+ Tauri shell can later implement
+// them via its native Rust backend without touching call sites.
+//
+// The Phase 3 web implementation targets the "save this transcript"
+// flow (export Markdown / JSON from the Host UI). It uses the
+// standard Blob + anchor download trick — no `chrome.*`, no File
+// System Access API (which WKWebView does not ship), no
+// `navigator.serviceWorker`. The caller does not need to know any of
+// that; it just calls `saveAs(...)`.
+//
+// Phase 4 Tauri replaces the web impl with a binding that calls
+// Rust's `rfd::FileDialog` + `fs::write` — same public surface.
+
+/**
+ * Supported export formats. Kept as a closed union so the switch
+ * statements that branch on it at the consumer side (setting
+ * Content-Type / default extension) stay exhaustive.
+ */
+export type FileExportFormat = "markdown" | "json" | "text";
+
+/**
+ * Input shape for a "save as …" prompt. The file contents live in
+ * memory; for the multi-megabyte-transcript edge case Phase 4 Tauri
+ * will add a streaming variant — Phase 3 web does not need it because
+ * a 4-hour meeting transcript is a few hundred KB of UTF-8.
+ */
+export interface SaveAsRequest {
+  /** Suggested filename including extension (e.g. "meeting-2026-04-17.md"). */
+  readonly suggestedName: string;
+  /** In-memory content to write. UTF-8 for text formats; caller serializes. */
+  readonly content: string;
+  /** Format hint — drives the Blob's MIME type and the suggested extension
+   *  when the OS picker asks. */
+  readonly format: FileExportFormat;
+}
+
+/**
+ * Outcome of a save attempt. `cancelled` = user dismissed the picker;
+ * `written` = the browser (or Tauri) confirmed the write. Web's
+ * Blob-download trick cannot distinguish "user hit Save" from "user
+ * hit Cancel" in the browser's download prompt, so the Web impl
+ * always reports `written` once the anchor click has dispatched —
+ * an acceptable lie because the worst case is the user sees a
+ * "saved" toast when they chose Cancel (harmless compared to the
+ * inverse).
+ */
+export type SaveAsResult =
+  | { readonly kind: "written"; readonly finalName: string }
+  | { readonly kind: "cancelled" };
+
+/**
+ * The port. Everything else the Host UI needs from the filesystem
+ * (open an existing corpus file, tail a log) will grow here rather
+ * than spreading into ad-hoc Blob helpers across components.
+ */
+export interface FileSystemProvider {
+  /**
+   * Prompt the user to save the supplied content under the suggested
+   * name. Resolves when the operation is observably complete (write
+   * finished on Tauri; download dispatched on Web).
+   */
+  saveAs(req: SaveAsRequest): Promise<SaveAsResult>;
+
+  /**
+   * True when the provider can produce a user-visible save dialog at
+   * all. Web is always `true` (Blob download works in every target
+   * browser). Tauri will be `true` after the shell's permissions
+   * grant a save path; an unsandboxed fallback may report `false`.
+   */
+  isSupported(): boolean;
+}

--- a/frontend_web/src/providers/NotificationProvider/WebNotificationProvider.ts
+++ b/frontend_web/src/providers/NotificationProvider/WebNotificationProvider.ts
@@ -1,0 +1,66 @@
+// frontend_web/src/providers/NotificationProvider/WebNotificationProvider.ts
+//
+// Phase 3 web implementation: the standard `Notification` Web API.
+// No `chrome.*`, no Service Worker push (ADR-0002 Constraint 3; push
+// notifications would require a Service Worker + a push subscription
+// endpoint neither of which Aegis ships at this tier). Phase 4 Tauri
+// will replace this with `@tauri-apps/plugin-notification`.
+
+import type {
+  NotificationPermissionState,
+  NotificationProvider,
+  NotificationRequest,
+} from "./types";
+
+export class WebNotificationProvider implements NotificationProvider {
+  getPermission(): NotificationPermissionState {
+    if (typeof Notification === "undefined") {
+      return "unsupported";
+    }
+    // Notification.permission returns "granted" | "denied" | "default".
+    return Notification.permission;
+  }
+
+  async requestPermission(): Promise<NotificationPermissionState> {
+    if (typeof Notification === "undefined") {
+      return "unsupported";
+    }
+    // Safari ≥ 16 and every other target WebView ship the
+    // Promise-returning form; ADR-0002 already documents Firefox /
+    // Safari as unsupported for the host role, so the old callback-
+    // only fallback is not worth carrying.
+    return Notification.requestPermission();
+  }
+
+  show(req: NotificationRequest): boolean {
+    const perm = this.getPermission();
+    if (perm !== "granted") {
+      return false;
+    }
+    // Build NotificationOptions with conditional-spread because
+    // tsconfig's `exactOptionalPropertyTypes: true` forbids passing
+    // `undefined` explicitly — absence and `undefined` are distinct.
+    const opts: NotificationOptions = {
+      // Web Notification spec has no first-class severity; `silent`
+      // approximates "info" so error-severity notifications still
+      // beep. Tauri will map the severity directly when it lands.
+      silent: req.severity === "info",
+      ...(req.body !== undefined ? { body: req.body } : {}),
+      ...(req.tag !== undefined ? { tag: req.tag } : {}),
+    };
+    try {
+      new Notification(req.title, opts);
+      return true;
+    } catch {
+      // Some WebViews throw when the Notification constructor is
+      // called from a non-user-activation context. Swallow — the
+      // caller sees a `false` return and can fall back to an
+      // in-page toast.
+      return false;
+    }
+  }
+
+  isSupported(): boolean {
+    return typeof Notification !== "undefined";
+  }
+}

--- a/frontend_web/src/providers/NotificationProvider/index.ts
+++ b/frontend_web/src/providers/NotificationProvider/index.ts
@@ -1,0 +1,21 @@
+// frontend_web/src/providers/NotificationProvider/index.ts
+//
+// Public surface of the NotificationProvider port. Re-exports types
+// and the factory. Concrete implementations stay hidden behind the
+// port so the Phase 4 Tauri swap is a one-line change here.
+
+import { WebNotificationProvider } from "./WebNotificationProvider";
+import type { NotificationProvider } from "./types";
+
+export type {
+  NotificationPermissionState,
+  NotificationProvider,
+  NotificationRequest,
+  NotificationSeverity,
+} from "./types";
+
+export { WebNotificationProvider };
+
+export function pickNotificationProvider(): NotificationProvider {
+  return new WebNotificationProvider();
+}

--- a/frontend_web/src/providers/NotificationProvider/types.ts
+++ b/frontend_web/src/providers/NotificationProvider/types.ts
@@ -1,0 +1,98 @@
+// frontend_web/src/providers/NotificationProvider/types.ts
+//
+// ADR-0002 Constraint 5: desktop notifications must sit behind a
+// provider interface so Phase 4 Tauri can call the OS notification
+// center natively (tauri-plugin-notification) while Phase 3 web uses
+// the standard `Notification` Web API.
+//
+// Aegis uses notifications for chief-of-staff-relevant events the user
+// would otherwise miss when the browser tab is not focused: "meeting
+// participant joined", "host audio dropped", "transcription fell
+// behind", etc. The provider does NOT handle in-page toasts (those
+// are a pure React-component concern); it handles cross-tab /
+// out-of-focus OS-level surfaces.
+//
+// Notifications are always permission-gated and always dismissible;
+// the provider returns whatever the platform offers and the caller
+// degrades gracefully when the permission is absent.
+
+/**
+ * Platform permission state. Matches the `NotificationPermission`
+ * DOM type (so callers branching on either get the same three
+ * values) plus an `unsupported` variant covering WebViews that don't
+ * expose the Notification API at all.
+ */
+export type NotificationPermissionState =
+  | "granted"
+  | "denied"
+  | "default"
+  | "unsupported";
+
+/**
+ * Severity hint. Drives the default OS icon / sound on Tauri and
+ * maps to a notification style on the Web (Web does not expose
+ * severity directly — the hint is metadata for UI analytics and for
+ * matching the Tauri surface).
+ */
+export type NotificationSeverity = "info" | "warning" | "error";
+
+export interface NotificationRequest {
+  readonly title: string;
+  readonly body?: string;
+  readonly severity?: NotificationSeverity;
+  /**
+   * Monotonic-ish identifier a caller can reuse to dedupe repeat
+   * notifications — e.g. "ingest-stall" emitted every 30s while the
+   * condition persists should not spam the OS with twelve copies. Web
+   * passes this as `Notification.tag`; Tauri will use it as a
+   * replacement key.
+   */
+  readonly tag?: string;
+}
+
+/**
+ * The port. `show()` is explicitly fire-and-forget — notifications
+ * are a one-way signal; the caller never blocks on user interaction.
+ * If click-through actions become necessary (Phase 5+?), they will
+ * grow here as an additional return type, not as a breaking change.
+ */
+export interface NotificationProvider {
+  /**
+   * Current permission state. Cheap, synchronous, polled at every
+   * notify call — no caching, so a mid-session permission change
+   * (rare but possible in Web) takes effect immediately.
+   */
+  getPermission(): NotificationPermissionState;
+
+  /**
+   * Request permission from the user. Web opens the browser's
+   * permission prompt; Tauri is a no-op if the app's installer
+   * already granted notification rights, or defers to the OS
+   * notification center otherwise.
+   *
+   * Resolves with the post-prompt state. Callers MAY show this
+   * behind a user-gesture (click) to satisfy browsers that only
+   * honor permission prompts in user-activation contexts.
+   */
+  requestPermission(): Promise<NotificationPermissionState>;
+
+  /**
+   * Dispatch a notification if permission allows. Silently no-ops
+   * when permission is `denied` or `unsupported`; callers should
+   * not conditionalize on the permission state — that's the
+   * provider's job. The `default` case shows nothing and returns
+   * false (caller may choose to prompt for permission at that
+   * moment).
+   *
+   * Returns whether the notification was dispatched.
+   */
+  show(req: NotificationRequest): boolean;
+
+  /**
+   * True when the platform has any form of notification UI
+   * available. Web returns `"Notification" in window`; Tauri will
+   * always be true on supported OSes (macOS / Windows / Linux
+   * D-Bus).
+   */
+  isSupported(): boolean;
+}

--- a/tools/scripts/check_frontend_tauri_compliance.sh
+++ b/tools/scripts/check_frontend_tauri_compliance.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Aegis Core — ADR-0002 Phase 3 Web Frontend Tauri-compatibility gate.
+#
+# Each constraint from ADR-0002 §"Constraints on the Phase 3 Web
+# Frontend" gets a specific grep that fails the check if the pattern
+# appears in `frontend_web/src/` OUTSIDE the provider directory that
+# is explicitly allowed to use the underlying browser API.
+#
+# Constraints covered:
+#   1. No `chrome.*` namespace                → grep chrome.
+#   2. Audio capture behind AudioCaptureProvider — only that dir may
+#      touch `navigator.mediaDevices`         → grep navigator.mediaDevices
+#   3. No Service Worker for core             → grep navigator.serviceWorker
+#   4. No SharedArrayBuffer                   → grep SharedArrayBuffer
+#   5. Filesystem / notification / auto-update behind their providers —
+#      the FileSystemProvider / NotificationProvider / AutoUpdateProvider
+#      dirs are the only places that may use Blob-download / Notification /
+#      updater APIs respectively. Spot-checked: notifications outside
+#      NotificationProvider dir may not call `new Notification(...)`.
+#   6. No large-client-side-storage assumption — this check is
+#      informational only (hard to detect via grep without false
+#      positives on in-memory object usage); the pattern warns on any
+#      `IndexedDB` reference in the source so a reviewer can confirm
+#      it's the small-object tier.
+#
+# Runs in under a second. Called from pre-commit (frontend hunk) and
+# in CI. Exits non-zero on any violation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SRC="$REPO_ROOT/frontend_web/src"
+
+if [[ ! -d "$SRC" ]]; then
+  echo "error: $SRC does not exist" >&2
+  exit 1
+fi
+
+VIOLATIONS=0
+
+# ---- Helper: grep and report violation ----
+# Args: <rule-name> <pattern> [exclude-path-fragment]
+#
+# Skips comment lines. The heuristic: after grep's `filename:lineno:`
+# prefix, if the line content starts with optional whitespace followed
+# by `//`, `*`, or `/*`, it's a single-line comment or a block-comment
+# line and we ignore it. This catches the common case where an ADR
+# reference legitimately mentions a forbidden API name inside a JSDoc
+# block (e.g. "we do NOT call navigator.serviceWorker"). Multi-line
+# block comments where the forbidden name appears on a non-`*`-prefixed
+# line are not handled — flag-a-false-positive and refactor the comment
+# if that ever happens.
+check() {
+  local rule="$1"
+  local pattern="$2"
+  local exclude="${3:-}"
+  local matches
+  # -R recursive, -I skip binary, -n line numbers, -E extended regex.
+  # Type set via --include=*.ts --include=*.tsx so we don't scan
+  # generated proto stubs in src/gen/ — those come from upstream proto
+  # codegen and cannot be audited line-by-line.
+  local comment_filter='[^:]*:[^:]*:[[:space:]]*(//|\*|/\*)'
+  if [[ -n "$exclude" ]]; then
+    matches="$(grep -RInE --include='*.ts' --include='*.tsx' \
+      --exclude-dir='gen' \
+      "$pattern" "$SRC" \
+      | grep -v -E "$comment_filter" \
+      | grep -v "$exclude" || true)"
+  else
+    matches="$(grep -RInE --include='*.ts' --include='*.tsx' \
+      --exclude-dir='gen' \
+      "$pattern" "$SRC" \
+      | grep -v -E "$comment_filter" || true)"
+  fi
+  if [[ -n "$matches" ]]; then
+    echo "✗ ADR-0002 $rule violated:"
+    echo "$matches" | sed 's/^/    /'
+    VIOLATIONS=$((VIOLATIONS + 1))
+  fi
+}
+
+echo "== ADR-0002 Phase 3 Web Frontend compliance check =="
+echo "   source: frontend_web/src/  (excluding src/gen/)"
+echo
+
+# Constraint 1 — chrome.* namespace.
+# Excludes `chrome.runtime.*` comment mentions; pattern is the
+# characteristic `chrome.` call-site shape: an identifier `chrome`
+# followed by a property access, at the start of a statement or after
+# a `(`, `=`, `!`, `&`, `|`, `?`, `,`, space. This rules out string
+# literals mentioning "chrome.runtime" in comments.
+check "Constraint 1 (no chrome.* namespace)" \
+  '(^|[^A-Za-z0-9_.])chrome\.[a-zA-Z]'
+
+# Constraint 2 — navigator.mediaDevices may only appear inside the
+# AudioCaptureProvider directory.
+check "Constraint 2 (navigator.mediaDevices only in AudioCaptureProvider)" \
+  'navigator\.mediaDevices' \
+  '/AudioCaptureProvider/'
+
+# Constraint 3 — no Service Worker registration. `navigator.serviceWorker`
+# is the access surface; we allow zero uses outside of the one spot
+# that might legitimately register (none today).
+check "Constraint 3 (no Service Worker for core)" \
+  'navigator\.serviceWorker'
+
+# Constraint 4 — no SharedArrayBuffer references.
+check "Constraint 4 (no SharedArrayBuffer)" \
+  'SharedArrayBuffer'
+
+# Constraint 5a — notifications only via NotificationProvider.
+check "Constraint 5 (notifications only via NotificationProvider)" \
+  'new Notification\(' \
+  '/NotificationProvider/'
+
+# Constraint 5b — downloads only via FileSystemProvider.
+# `a.download = ...` / `anchor.download = ...` is the characteristic
+# Blob-download trick; a less formal grep on `URL.createObjectURL` is
+# too noisy (audio streams legitimately use it). We look for the
+# anchor-download idiom specifically.
+check "Constraint 5 (Blob downloads only via FileSystemProvider)" \
+  '\.download = ' \
+  '/FileSystemProvider/'
+
+# Constraint 6 — informational warning only; IndexedDB is permitted
+# but large-binary storage is not. Flag for reviewer attention.
+INDEXEDDB="$(grep -RInE --include='*.ts' --include='*.tsx' \
+  --exclude-dir='gen' \
+  'indexedDB\.open|IDBDatabase' "$SRC" || true)"
+if [[ -n "$INDEXEDDB" ]]; then
+  echo "ℹ  Constraint 6 note — IndexedDB references found. Reviewer"
+  echo "   should confirm these store small JSON only, not model"
+  echo "   blobs / audio. References:"
+  echo "$INDEXEDDB" | sed 's/^/    /'
+fi
+
+echo
+
+if [[ "$VIOLATIONS" -gt 0 ]]; then
+  echo "FAIL — $VIOLATIONS constraint(s) violated."
+  echo "See docs/adr/0002-desktop-shell-technology.md §\"Constraints"
+  echo "on the Phase 3 Web Frontend\" for the full rules."
+  exit 1
+fi
+
+echo "OK — all ADR-0002 Phase 3 Constraints are satisfied."


### PR DESCRIPTION
## Summary

Closes out ADR-0002 Constraint 5 — "filesystem, notification, and
auto-update concerns behind providers" — with three new ports
(FileSystem / Notification / AutoUpdate) each landing as
`types.ts` + Web implementation + `index.ts` + factory, matching
the existing AuthProvider / AudioCaptureProvider pattern.

Adds a lightweight `tools/scripts/check_frontend_tauri_compliance.sh`
that greps `frontend_web/src/` for the six forbidden patterns in
ADR-0002 §"Constraints on the Phase 3 Web Frontend", wired into CI
as a dedicated job.

## Ports landed

- **`FileSystemProvider`** — Blob + anchor-click download (Web); Phase 4 Tauri slot awaits.
- **`NotificationProvider`** — standard `Notification` API, Promise form only; `silent` severity hint; graceful no-op on denied / unsupported.
- **`AutoUpdateProvider`** — Web: `checkForUpdate` → `up-to-date` (browser IS the updater); `applyUpdate` throws with guidance. Phase 4 Tauri drops in `@tauri-apps/plugin-updater` behind the same surface.

## Compliance gate

The grep checks the six ADR-0002 rules:

1. `chrome.*` namespace
2. `navigator.mediaDevices` outside `AudioCaptureProvider/`
3. `navigator.serviceWorker` anywhere
4. `SharedArrayBuffer` anywhere
5a. `new Notification(...)` outside `NotificationProvider/`
5b. `.download = ...` Blob-download idiom outside `FileSystemProvider/`
6. IndexedDB informational warning (reviewer-audited, not auto-failing)

Comment-line heuristic skips JSDoc references so explanatory prose like "we deliberately do NOT call navigator.serviceWorker" doesn't trigger false positives.

## Test plan

- [x] `./tools/scripts/frontend.sh typecheck` — `tsc --noEmit` green
- [x] `./tools/scripts/frontend.sh build` — Vite: 177 modules, 351 KB main bundle
- [x] `./tools/scripts/check_frontend_tauri_compliance.sh` — 0 violations locally
- [ ] CI full 7-job matrix green (6 existing + new `frontend-tauri-compliance`) — verified per CLAUDE.md Rule 1 full-matrix check after this PR's run lands

## What's NOT in this PR (Phase 3c scope remaining)

- Slice 2: Login flow + "New Meeting" corpus selector + LAN QR code
- Slice 3: Two-phase transcript consent + audio-processing consent
- Slice 4: Speaker label tagging + live prompter + End Meeting
- Slice 5: Export flow (consumes FileSystemProvider landed here)
- Slice 6: Cross-WebView acceptance + Playwright live-browser smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)