### PR TITLE
Phase 3c Slice 2 — RAG opt-in + TAIL=5 + ADR-0023 demo-horizon defaults

### DIFF
--- a/docs/adr/0023-demo-horizon-defaults-host-state-and-rag-binding.md
+++ b/docs/adr/0023-demo-horizon-defaults-host-state-and-rag-binding.md
@@ -1,0 +1,166 @@
+# ADR-0023: Demo-horizon defaults — host state persistence + RAG binding
+
+| Field    | Value |
+| -------- | ----- |
+| Status   | Accepted (2026-04-18) for the demo horizon; Phase 4 re-evaluation triggers below |
+| Date     | 2026-04-18 |
+| Deciders | Project author |
+| Supersedes | — |
+| Superseded by | — |
+
+## Context
+
+Phase 3c Slice 2 had to make two small design calls that each have a
+bigger shadow than their LOC count suggests. Rather than resolving
+them silently in code, this ADR records both so Phase 4 does not
+relitigate either under deadline pressure.
+
+### Decision A — Host-side session state persistence
+
+**What**: the Host page's auth principal + active-meeting state lives
+in React reducer state only. No `sessionStorage`, no `localStorage`,
+no HttpOnly cookie. A page refresh returns the host to the
+`signed-out` branch and — if a meeting was active — ends the
+meeting server-side (ICE disconnect on the gateway's side triggers
+the graceful-shutdown path documented in ADR-0006).
+
+**Why not sessionStorage / localStorage / cookie today**:
+
+- **sessionStorage (~30 LOC, 1 hour)**: solves refresh persistence
+  per-tab but adds XSS exposure for tokens and is still wiped on tab
+  close. Marginal UX win over in-memory.
+- **localStorage**: same XSS exposure, longer lifetime — larger
+  blast radius. Same marginal UX over sessionStorage.
+- **HttpOnly Secure cookie + `GetMe` RPC (1–2 days)**: the secure
+  answer, but pairing it to the current `StaticJWTProvider` stub
+  wastes work that a Phase 4 Cognito wiring will redo. CORS,
+  cross-origin `SameSite`, CSRF strategy, dev-mode Vite proxy all
+  have to be designed now against a backend that does not yet exist.
+
+**Product argument**: the chief-of-staff is *actively driving* the
+meeting. If they refresh mid-meeting, the WebRTC connection and
+audio-capture `MediaStream` are gone regardless of token survival
+— the meeting has already ended for operational reasons. Adding
+state persistence only solves "restore the meeting form inputs after
+an accidental refresh before capture started," which is a marginal
+benefit not worth the XSS surface of JS-accessible storage.
+
+**Accepted consequence**: a host refresh loses everything. We treat
+this as the product contract, not a bug.
+
+### Decision B — RAG corpus binding is opt-in
+
+**What**: `CreateMeetingRequest.rag_id` accepts an empty string,
+meaning "no RAG binding — transcript-only meeting; staff provides
+hints manually". Gateway must NOT reject empty rag_id with
+`INVALID_ARGUMENT` / `NOT_FOUND`. Engine session start must tolerate
+empty rag_id (skip any RAG init when the query path lands in
+Phase 4+). Frontend `HostPage` dropdown defaults to "(No corpus)".
+
+**Why opt-in**:
+
+- Plenty of meetings are better served by the chief-of-staff's own
+  judgement than by a mediocre retrieval hit. A forced default
+  corpus trains the user to ignore retrieval quality rather than
+  notice when it helps.
+- Every corpus binding carries a non-zero engine-side cost once the
+  query path lives (embedder warmup, Qdrant socket, HNSW index
+  pages in cache). Opting in means meetings that do not want RAG do
+  not pay for RAG.
+- It sharpens the product framing: Aegis's core promise is
+  real-time transcription + prompter; RAG is a premium augment.
+
+**Accepted consequence**: the Host UI must make the "no corpus"
+choice visible and non-punishing. Default dropdown text is
+`(No corpus — staff provides hints manually)`, not `Please select…`.
+
+## Decision
+
+Ship both A and B in Phase 3c Slice 2. Code changes in this ADR's
+landing PR:
+
+- `proto/aegis/v1/aegis.proto` — `rag_id` docstring explicitly
+  permits empty string; cross-references this ADR.
+- `gateway_go/internal/grpc/gateway_service.go` —
+  `CreateMeeting` drops the empty-rag_id `INVALID_ARGUMENT` branch.
+- `gateway_go/internal/grpc/gateway_service_test.go` — rename
+  `TestCreateMeetingRejectsEmptyRag` → `TestCreateMeetingAcceptsEmptyRag`
+  and flip the assertion.
+- `frontend_web/src/pages/Host/HostPage.tsx` — `RAG_CORPORA`
+  gains `{ value: "", label: "(No corpus — staff provides hints
+  manually)" }` as the first entry; `DEFAULT_RAG_ID = ""`; also
+  align `TRANSCRIPT_TAIL` (8 → 5) with Viewer's `PROMPTER_WINDOW`.
+
+No engine-side changes today — the RAG query path does not exist
+yet, so "empty rag_id skips RAG init" is trivially satisfied. The
+proto docstring on `StreamStart.rag_id` (`aegis.proto:461`) is the
+contract the engine must honor when query lands.
+
+## Phase 4 re-evaluation triggers
+
+Either decision SHOULD be revisited when:
+
+1. **Cognito JWT middleware goes live on the gateway.** ADR-0001
+   precondition. At that point a real long-lived session exists,
+   and HttpOnly cookies become the right shape rather than a
+   pre-mature commit. Bundle A's migration with that PR.
+2. **Multi-host meeting mode ships.** If two staff share a single
+   meeting (delegation, shift handover), in-memory state breaks the
+   UX. Decision A's in-memory posture then stops fitting.
+3. **A customer contract requires session recovery SLA.** Explicit
+   promise of "refresh survives" flips Decision A.
+4. **Query path latency drives a corpus pre-load default.** If
+   bge-m3 embedder warmup becomes the critical-path meeting-start
+   latency, a corpus preselection might be worth re-introducing —
+   but as a per-tenant preference, not a global default.
+
+None of the four triggers is close today. This ADR is the written
+commitment that neither decision is re-opened under deadline
+pressure before one of them fires.
+
+## Consequences
+
+### Positive
+
+- **Tiny code surface.** Both decisions land in Slice 2's budget
+  (~60 LOC + this ADR). No proto-wire changes, no CORS reshuffle.
+- **Consistent decision posture.** Same two-phase pattern as
+  ADR-0014 (β demo / δ production) and ADR-0022 (Phase 4 Cognito
+  multi-tenancy) — demo-horizon simplification + Phase 4 migration
+  trigger — makes the project's overall rhythm predictable.
+- **Honest product framing.** "No RAG is a first-class mode" is a
+  more truthful statement of what Aegis actually offers in Phase 3
+  than "RAG is the point and you must pick a corpus."
+
+### Negative
+
+- **Refresh UX regression on paper.** A reviewer reading the code
+  without this ADR may think we forgot to persist the session.
+  This ADR + the docstring in `HostPage.tsx` are the cure.
+- **Two Phase 4 migrations to schedule.** When Cognito lands, A's
+  cookie migration is one item; any query-path corpus-preference
+  work is another. Both are small individually but need to appear
+  on the Phase 4 burn-down.
+
+### Risks
+
+- **Customer demo of "I refreshed and lost everything" landing
+  badly.** Mitigation: the Host UI should surface a
+  "Meeting ended due to page refresh — start a new one" message
+  when a fresh load finds a recent meeting in localStorage
+  (hm — but we committed to no localStorage). Better mitigation:
+  documentation in user-facing help text explaining the contract.
+  Acceptable since the demo audience is internal.
+
+## Related
+
+- ADR-0001 — CreateMeeting + session-token issuance (the auth
+  context Decision A persists in memory).
+- ADR-0006 — ICE Consent Freshness + 4-hour graceful drain (what
+  happens server-side when the host refreshes).
+- ADR-0014 — Bazel build cache strategy (β demo / δ production —
+  same two-phase pattern this ADR inherits).
+- ADR-0020 — Engine owns inference (why "skip RAG init" is a
+  single-binary concern, not a microservice one).
+- ADR-0022 — Cloud multi-tenancy isolation (Phase 4 companion that
+  will bundle this ADR's Decision A migration).

--- a/frontend_web/src/gen/proto/aegis/v1/aegis_pb.ts
+++ b/frontend_web/src/gen/proto/aegis/v1/aegis_pb.ts
@@ -195,9 +195,15 @@ proto3.util.setEnumType(ControlKind, "aegis.v1.ControlKind", [
 export class CreateMeetingRequest extends Message<CreateMeetingRequest> {
   /**
    * Identifier of the RAG corpus to bind to this meeting. In Cloud mode
-   * this is a DynamoDB partition key; in Local mode it is a path
-   * identifier resolved relative to `./models/` (per CLAUDE.md Rule 6).
-   * Must reference a corpus the authenticated caller can access.
+   * this is a DynamoDB partition key; in Local mode it is a Qdrant
+   * collection name (e.g., `aegis_taiwan` from `engine seed`).
+   *
+   * An empty string means NO RAG binding — the meeting runs transcript-
+   * only and the chief-of-staff provides hints manually. This is a
+   * first-class mode, not an error case; see ADR-0023 §"Decision B —
+   * RAG opt-in" for the rationale. Gateway MUST NOT reject empty
+   * rag_id with NOT_FOUND. When non-empty, rag_id must reference a
+   * corpus the authenticated caller can access.
    *
    * @generated from field: string rag_id = 1;
    */
@@ -1352,7 +1358,9 @@ export class SessionStart extends Message<SessionStart> {
   tenantId = "";
 
   /**
-   * RAG corpus identifier to bind to this session.
+   * RAG corpus identifier to bind to this session. Empty string means
+   * the session has no RAG binding (transcript-only, manual hints);
+   * engine MUST skip RAG init for empty rag_id. See ADR-0023 §"Decision B".
    *
    * @generated from field: string rag_id = 3;
    */

--- a/frontend_web/src/pages/Host/HostPage.tsx
+++ b/frontend_web/src/pages/Host/HostPage.tsx
@@ -68,23 +68,37 @@ const ALL_MODES: { readonly value: CaptureMode; readonly label: string }[] = [
   { value: "microphone-and-tab", label: "Both (mic + tab, mixed)" },
 ];
 
-// Preset RAG corpora. Keep the list short and curated — a live system
-// would populate this from a per-tenant ListCorpora RPC (ADR-0004
-// future work). The `value` is what the Gateway's CreateMeeting RPC
-// sees (its `rag_id` proto field); the `label` is the human-friendly
-// dropdown text.
+// Preset RAG corpora. Per ADR-0023 §"Decision B" the empty-string
+// option is the DEFAULT — the chief-of-staff must opt IN to a RAG
+// corpus. "No corpus" is a first-class mode, not a degraded fallback:
+// plenty of meetings are better served by staff providing hints
+// manually than by a mediocre retrieval hit.
 //
-// The first entry is the dropdown default — cheap demo that exercises
-// the pipeline end-to-end without caring which corpus responds.
+// The remaining entries are curated presets. A live system will
+// replace this with a per-tenant ListCorpora RPC once the query path
+// lands (Phase 4+); until then, the list is authored here and must be
+// kept in sync with what `engine seed` has actually populated in the
+// target Qdrant. `aegis_taiwan` is Slice 6's seeded corpus; the
+// `demo-rag-*` entries are placeholders for future demo content.
+//
+// The `value` is what the Gateway's CreateMeeting RPC sees in the
+// `rag_id` proto field; empty string means "no RAG binding". The
+// `label` is the human-friendly dropdown text.
 const RAG_CORPORA: { readonly value: string; readonly label: string }[] = [
+  { value: "", label: "(No corpus — staff provides hints manually)" },
+  { value: "aegis_taiwan", label: "Taiwan reference (Slice 6 seeded)" },
   { value: "demo-rag-general", label: "General demo corpus" },
   { value: "demo-rag-engineering", label: "Engineering knowledge base" },
   { value: "demo-rag-sales", label: "Sales deck library" },
   { value: "demo-rag-support", label: "Customer support knowledge" },
 ];
-const DEFAULT_RAG_ID = RAG_CORPORA[0]!.value;
+const DEFAULT_RAG_ID = RAG_CORPORA[0]!.value; // "" — opt-in RAG
 
-const TRANSCRIPT_TAIL = 8; // lines visible to the host
+// Rolling transcript window shown on the host UI. Matches the
+// Viewer-side `PROMPTER_WINDOW` (5) so host and viewers see the same
+// line count; diverging would confuse the host about what the room
+// is actually reading.
+const TRANSCRIPT_TAIL = 5;
 
 const DEPLOY_MODE = (import.meta.env["VITE_AEGIS_DEPLOY_MODE"] ?? "local") as
   | "cloud"

--- a/gateway_go/gen/go/aegis/v1/aegis.pb.go
+++ b/gateway_go/gen/go/aegis/v1/aegis.pb.go
@@ -244,9 +244,15 @@ func (ControlKind) EnumDescriptor() ([]byte, []int) {
 type CreateMeetingRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Identifier of the RAG corpus to bind to this meeting. In Cloud mode
-	// this is a DynamoDB partition key; in Local mode it is a path
-	// identifier resolved relative to `./models/` (per CLAUDE.md Rule 6).
-	// Must reference a corpus the authenticated caller can access.
+	// this is a DynamoDB partition key; in Local mode it is a Qdrant
+	// collection name (e.g., `aegis_taiwan` from `engine seed`).
+	//
+	// An empty string means NO RAG binding — the meeting runs transcript-
+	// only and the chief-of-staff provides hints manually. This is a
+	// first-class mode, not an error case; see ADR-0023 §"Decision B —
+	// RAG opt-in" for the rationale. Gateway MUST NOT reject empty
+	// rag_id with NOT_FOUND. When non-empty, rag_id must reference a
+	// corpus the authenticated caller can access.
 	RagId string `protobuf:"bytes,1,opt,name=rag_id,json=ragId,proto3" json:"rag_id,omitempty"`
 	// Optional human-readable meeting title (displayed in viewer UI and
 	// in the export metadata). Max 200 characters.
@@ -1328,7 +1334,9 @@ type SessionStart struct {
 	// Tenant / organization identifier. Empty in Local mode; populated
 	// in Cloud mode from the host's Cognito JWT.
 	TenantId string `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
-	// RAG corpus identifier to bind to this session.
+	// RAG corpus identifier to bind to this session. Empty string means
+	// the session has no RAG binding (transcript-only, manual hints);
+	// engine MUST skip RAG init for empty rag_id. See ADR-0023 §"Decision B".
 	RagId string `protobuf:"bytes,3,opt,name=rag_id,json=ragId,proto3" json:"rag_id,omitempty"`
 	// Audio format of the PcmChunk stream that will follow.
 	AudioFormat *AudioFormat `protobuf:"bytes,4,opt,name=audio_format,json=audioFormat,proto3" json:"audio_format,omitempty"`

--- a/gateway_go/internal/grpc/gateway_service.go
+++ b/gateway_go/internal/grpc/gateway_service.go
@@ -157,11 +157,16 @@ func newWithProber(
 // CreateMeeting is the entrypoint for a new session.
 //
 // Error mapping (aligned with proto/aegis/v1/aegis.proto):
-//   - INVALID_ARGUMENT   — empty rag_id, or title over 200 chars.
+//   - INVALID_ARGUMENT   — nil request, or title over 200 chars.
 //   - UNAVAILABLE        — engine Health RPC failed entirely.
 //   - RESOURCE_EXHAUSTED — engine reports !Ready (A4 swaps this for
 //     the real ResourceBudget reservation).
 //   - INTERNAL           — registry Create or JWT sign failed.
+//
+// NOTE: empty rag_id is NOT an error. Per ADR-0023 §"Decision B —
+// RAG opt-in", a meeting with empty rag_id runs transcript-only and
+// the chief-of-staff provides hints manually. First-class mode, not
+// a degraded fallback.
 //
 // UNAUTHENTICATED / PERMISSION_DENIED paths land in A5 with the
 // Cognito JWT middleware; Local mode has no caller identity today.
@@ -169,8 +174,8 @@ func (s *GatewayService) CreateMeeting(
 	ctx context.Context,
 	req *aegisv1.CreateMeetingRequest,
 ) (*aegisv1.CreateMeetingResponse, error) {
-	if req == nil || req.GetRagId() == "" {
-		return nil, status.Error(codes.InvalidArgument, "rag_id is required")
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is nil")
 	}
 	if len(req.GetTitle()) > 200 {
 		return nil, status.Error(codes.InvalidArgument, "title exceeds 200 characters")

--- a/gateway_go/internal/grpc/gateway_service_test.go
+++ b/gateway_go/internal/grpc/gateway_service_test.go
@@ -112,14 +112,27 @@ func TestCreateMeetingHappyPath(t *testing.T) {
 	}
 }
 
-func TestCreateMeetingRejectsEmptyRag(t *testing.T) {
+// Per ADR-0023 §"Decision B — RAG opt-in", empty rag_id is a
+// first-class mode (staff provides hints manually), not an error.
+// Gateway MUST accept CreateMeeting with empty rag_id.
+func TestCreateMeetingAcceptsEmptyRag(t *testing.T) {
 	svc := newTestService(t, fakeEngineHealth(&aegisv1.HealthResponse{Ready: true}))
 	client, cleanup := setupServer(t, svc)
 	defer cleanup()
 
-	_, err := client.CreateMeeting(context.Background(), &aegisv1.CreateMeetingRequest{})
-	if got := status.Code(err); got != codes.InvalidArgument {
-		t.Fatalf("empty rag_id: got code %v, want InvalidArgument", got)
+	resp, err := client.CreateMeeting(
+		context.Background(),
+		&aegisv1.CreateMeetingRequest{}, // empty rag_id
+	)
+	if err != nil {
+		t.Fatalf("CreateMeeting with empty rag_id: got error %v, want OK", err)
+	}
+	if resp.GetSessionId() == "" {
+		t.Fatal("CreateMeeting with empty rag_id: empty session_id in response")
+	}
+	if svc.registry.Len() != 1 {
+		t.Fatalf("registry.Len after empty-rag CreateMeeting: got %d, want 1",
+			svc.registry.Len())
 	}
 }
 

--- a/proto/aegis/v1/aegis.proto
+++ b/proto/aegis/v1/aegis.proto
@@ -137,9 +137,15 @@ service Gateway {
 
 message CreateMeetingRequest {
   // Identifier of the RAG corpus to bind to this meeting. In Cloud mode
-  // this is a DynamoDB partition key; in Local mode it is a path
-  // identifier resolved relative to `./models/` (per CLAUDE.md Rule 6).
-  // Must reference a corpus the authenticated caller can access.
+  // this is a DynamoDB partition key; in Local mode it is a Qdrant
+  // collection name (e.g., `aegis_taiwan` from `engine seed`).
+  //
+  // An empty string means NO RAG binding — the meeting runs transcript-
+  // only and the chief-of-staff provides hints manually. This is a
+  // first-class mode, not an error case; see ADR-0023 §"Decision B —
+  // RAG opt-in" for the rationale. Gateway MUST NOT reject empty
+  // rag_id with NOT_FOUND. When non-empty, rag_id must reference a
+  // corpus the authenticated caller can access.
   string rag_id = 1;
 
   // Optional human-readable meeting title (displayed in viewer UI and
@@ -457,7 +463,9 @@ message SessionStart {
   // in Cloud mode from the host's Cognito JWT.
   string tenant_id = 2;
 
-  // RAG corpus identifier to bind to this session.
+  // RAG corpus identifier to bind to this session. Empty string means
+  // the session has no RAG binding (transcript-only, manual hints);
+  // engine MUST skip RAG init for empty rag_id. See ADR-0023 §"Decision B".
   string rag_id = 3;
 
   // Audio format of the PcmChunk stream that will follow.


### PR DESCRIPTION
## Summary

Two small contract changes the Host UI needs before Slices 3–6 can
reason cleanly about "no corpus" meetings and prompter alignment.
Both are recorded in [ADR-0023](docs/adr/0023-demo-horizon-defaults-host-state-and-rag-binding.md)
so Phase 4 does not relitigate.

### Decision A — host-side session state stays in-memory

No code change; codifies status quo. Host refresh during active
meeting = meeting ends (WebRTC + MediaStream are gone regardless of
token survival). Phase 4 re-evaluates when Cognito JWT middleware
lands — HttpOnly cookie + GetMe RPC become natural at that point.

### Decision B — RAG binding is opt-in

- `rag_id` docstrings (both CreateMeetingRequest + StreamStart) now
  permit empty string = "no RAG binding, staff provides hints
  manually". First-class mode.
- Gateway drops the empty-`rag_id` `INVALID_ARGUMENT` rejection.
- Gateway test renamed + flipped (`RejectsEmptyRag` → `AcceptsEmptyRag`).
- `HostPage.RAG_CORPORA` gets a leading `(No corpus — …)` entry
  with empty value; `DEFAULT_RAG_ID = ""`; `aegis_taiwan` added
  as a real corpus (Slice 6 seeded).

Engine side is a no-op today (RAG query path does not exist yet);
when query lands in Phase 4+, the proto docstring is the contract.

### Prompter alignment

`TRANSCRIPT_TAIL = 8` → `5` — matches Viewer's `PROMPTER_WINDOW=5`.
Host + viewer prompter line-count divergence confused demo UX.

## Test plan

- [x] `./tools/scripts/frontend.sh typecheck` — `tsc --noEmit` green
- [x] `./tools/scripts/check_frontend_tauri_compliance.sh` — 0 violations
- [x] `./tools/bazelisk/bazelisk test //gateway_go/internal/grpc/...` — all pass, `AcceptsEmptyRag` verifies
- [x] `./tools/bazelisk/bazelisk build //gateway_go/... //engine_cpp/cmd/engine:engine //proto/aegis/v1:aegis_cc_grpc` — 2608 actions green
- [ ] CI 7-job matrix green (verified per CLAUDE.md Rule 1 full-matrix check)

## Phase 3c progress

After merge: 3 of 11 Host-UI checklist items done (Login / New
Meeting / QR pre-existed; Slice 1 added 3 provider stubs; Slice 2
reshapes the New Meeting surface). Remaining:

- Slice 3 — audio + transcript consent flows
- Slice 4 — speaker label tagging
- Slice 5 — export (consumes FileSystemProvider from Slice 1)
- Slice 6 — cross-WebView + Playwright smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)