### PR TITLE
Phase 3c Slice 3 — consent flows (audio one-time + transcript 2-phase) + ADR-0024

### DIFF
--- a/docs/adr/0024-consent-flows-audio-and-transcript.md
+++ b/docs/adr/0024-consent-flows-audio-and-transcript.md
@@ -1,0 +1,244 @@
+# ADR-0024: Consent flows — audio-processing (one-time) + transcript (two-phase)
+
+| Field    | Value |
+| -------- | ----- |
+| Status   | Accepted (2026-04-18) for Phase 3c frontend; consent-ledger persistence deferred to Phase 4 (DynamoDB wiring) |
+| Date     | 2026-04-18 |
+| Deciders | Project author |
+| Supersedes | — |
+| Superseded by | — |
+
+## Context
+
+Aegis processes meeting audio in real time and produces transcripts
+that are *legally and ethically sensitive*: a participant's spoken
+words are PII under GDPR Art. 4(1), potentially Art. 9 special
+categories if health / political / religious content surfaces, and
+are a live target of BIPA / CCPA / state wiretap statutes across
+jurisdictions. ADR-0012 already removed the biometric-processing
+exposure by eliminating voiceprint matching, but the remaining
+surface — "the host can see a transcript on their screen and export
+it" — still requires a thought-through consent story.
+
+ARCHITECTURE.md §9.3 already specifies a one-time audio-processing
+consent captured at first use. This ADR extends that into a concrete
+three-part consent design for the Phase 3c Host UI:
+
+1. **Audio-processing consent** (ARCH §9.3 mandate): first use, once
+   per account per privacy-policy version.
+2. **Transcript panel visibility** (new): per-meeting opt-in for the
+   host to see the transcript on-screen during the meeting.
+3. **Transcript export**: per-export opt-in modal acknowledging
+   responsibility transfer when the host saves the transcript out.
+
+The third is operationally triggered by the export flow (Slice 5)
+but the modal component + audit emission live here (Slice 3) because
+they are consent infrastructure, not export infrastructure.
+
+## Decisions
+
+### Decision A — Audio-processing consent is a one-time, localStorage-persisted gate
+
+On the host's first visit to the authenticated Host page, a modal
+appears with the ARCH §9.3 copy verbatim:
+
+> *"Aegis transcribes your meeting audio in real time and generates
+> suggestion hints from a knowledge corpus you select. Audio is
+> processed only in memory and is never saved."*
+
+Only an `[Agree]` action is offered; there is no "decline" path —
+the app is unusable without this consent, so the honest UX is to
+refuse further interaction rather than paint a disabled shell.
+
+Upon acceptance, a consent record writes to `localStorage` keyed by
+policy version:
+
+```
+localStorage["aegis.consent.audio_processing.v1"] =
+  JSON.stringify({ accepted_at: <ISO 8601>, user_id: <sub>,
+                   policy_version: "v1" })
+```
+
+The `v1` segment of the key is load-bearing — if the policy copy
+changes materially (a new privacy-policy version), the `v2` key
+absence will re-prompt the user for explicit consent to the new
+terms. This is the "per privacy-policy-version" rule from ARCH §9.3.
+
+**Phase 4 migration**: the client-side localStorage record is a
+demo-horizon convenience. The ARCH §9.3-mandated consent ledger
+(persistent, append-only, 7-year retention) lives server-side in
+DynamoDB (Cloud) / SQLite (Local) and is wired in Phase 4 when the
+gateway learns to persist consent entries. The Phase 3 frontend
+emits the same consent-record shape via `console.info` so the Slice
+3 code path is compatible with a Phase 4 gateway RPC drop-in.
+
+### Decision B — Transcript panel is opt-in per meeting, default OFF
+
+The Host page's New Meeting form gains a toggle:
+
+> `[ ] Show live transcript on this screen`
+
+Default **OFF**. When the host toggles it ON, an inline notice
+appears below the toggle:
+
+> *Turning on the live transcript shows meeting content on your
+> screen. Aegis processes this data under GDPR Art. 6(1)(f)
+> (legitimate interests — operating the service you requested) and,
+> where participants' messages include special-category data, Art.
+> 9(2)(a) (your explicit consent to see it). You are responsible
+> for the physical security of your screen (bystanders, recording
+> devices) while the panel is visible.*
+
+The toggle state is passed to the component as a client-side flag
+only — it does NOT go over the wire to the Gateway. The backend
+keeps transcribing regardless; this decision is purely about what
+the host's browser RENDERS. If the host toggles OFF mid-meeting, the
+transcript div becomes a "Transcript display disabled — toggle on
+in the meeting form to view" placeholder.
+
+**Why default OFF:** privacy-preserving default. The chief-of-staff
+is *running* the meeting; they don't inherently need to watch the
+transcript. Opt-in acknowledges the screen-as-attack-surface risk
+(over-shoulder viewing, screenshots, accidental screen-share
+exposure).
+
+### Decision C — Transcript export requires phase-2 confirmation + audit log
+
+When the host initiates an export (Slice 5 wires the button), a
+modal appears before the save:
+
+> *You are about to save the meeting transcript to a file. By
+> proceeding, you confirm that:*
+>
+> - *You are responsible for the transcript file under your
+>   jurisdiction's data-protection laws from this moment forward.*
+> - *You will not share the file with anyone not authorized to see
+>   the meeting's contents.*
+> - *This action is recorded in the consent ledger with your user
+>   ID, session ID, timestamp, and client metadata.*
+>
+> `[Confirm export]` `[Cancel]`
+
+On confirm, the frontend:
+1. Writes an audit record with shape:
+   ```
+   { kind: "consent:transcript:export:confirmed",
+     user_id, session_id, exported_at: <ISO 8601>,
+     export_format: "markdown" | "json",
+     client_metadata: { user_agent, deploy_mode } }
+   ```
+2. In Phase 3: emits via `console.info` (no gateway wiring).
+3. In Phase 4: POSTs to a `LogConsentEvent` gateway RPC that
+   writes the DynamoDB consent-ledger row.
+
+The modal is a distinct, reusable component (`TranscriptExportConsentModal`).
+Slice 3 builds + exports it; Slice 5's export handler wires it in.
+
+### Decision D — NO `user-select: none` on transcript text
+
+Emphatic: transcript text **must remain selectable**. Reasoning:
+
+1. **Screenshots bypass it entirely.** Any attacker with a camera
+   or OS-level screenshot capability captures the text regardless
+   of `user-select`; the CSS rule's protection is theatrical.
+2. **It breaks screen readers and accessibility.** Sighted users
+   can still work around disabled selection (browser extensions,
+   right-click → Save As); screen-reader users cannot.
+3. **It signals a defense posture the app cannot deliver.** A user
+   who sees "I can't select this" assumes the text is protected —
+   but an actual leak-via-screenshot remains trivial. The honest
+   posture is to keep selection on and, if traceability matters,
+   layer on the watermark (Decision E).
+
+The Tauri-compliance script
+(`tools/scripts/check_frontend_tauri_compliance.sh`) is extended in
+Slice 3 to grep for `user-select:\s*none` and the React equivalent
+`userSelect:\s*["']none["']`; any occurrence fails CI.
+
+### Decision E — Watermarking is an optional Phase 4+ mitigation
+
+If operational experience shows transcript leak traceability is
+worth the visual cost, the Host page can layer a low-contrast
+watermark over the transcript pane containing:
+
+```
+<user_id> · <session_id short hash> · <timestamp YYYY-MM-DD HH:MM>
+```
+
+Attributes:
+- CSS `position: absolute`, opacity ≈ 0.08–0.12
+- Repeated diagonal pattern (not just a single corner mark —
+  screenshot-cropping should be expensive)
+- Color that has contrast 3–4:1 against transcript text so it
+  survives grayscale / print
+
+This is **not** implemented in Phase 3. It's documented here so the
+future adopter does not re-derive the design under pressure. The
+trigger to implement is a customer request for leak traceability,
+or an internal incident where leaked transcript would have been
+trackable.
+
+## Phase 4 triggers
+
+- Cognito JWT middleware wires in → consent ledger moves from
+  client-side localStorage + console.info to a real gateway RPC
+  persisting DynamoDB consent rows. Both A and C migrate.
+- First customer requires leak traceability → implement Decision E
+  watermarking.
+- DynamoDB consent-ledger table provisioned by ldz (per this repo's
+  standing #11 IRSA role future requirements, added 2026-04-18).
+
+## Consequences
+
+### Positive
+
+- **Consent surface is a contract, not vibes.** Every consent
+  gate has a written trigger, written copy, and a specified audit
+  shape. A reviewer can trace each gate back to ARCH §9.3 or
+  GDPR / BIPA language without re-deriving.
+- **Screenshots stay usable as debugging aids.** A supportive
+  accessibility posture + a realistic threat model together say
+  "selection stays on; watermark if you need traceability."
+- **Phase 3 / Phase 4 migration is small.** The consent-record
+  shape emitted in Phase 3 (`{user_id, session_id, timestamp,
+  client_metadata, kind}`) matches the future DynamoDB row
+  schema. Gateway RPC is a drop-in.
+
+### Negative
+
+- **First-use modal adds friction.** One extra click on the very
+  first Host page visit. Mitigated by the one-time nature (localStorage
+  persists) and the non-scary copy.
+- **Transcript-panel-OFF default feels surprising.** Users who
+  *want* to watch the live transcript must opt in every meeting.
+  Acceptable: the toggle is prominent in the form, not buried.
+
+### Risks
+
+- **localStorage can be wiped.** Browser clear-site-data, private
+  browsing mode, or user cookie-cleaners delete the audio-
+  processing consent record → user sees the modal again. This is
+  correct behavior: the consent was scoped to this localStorage,
+  and the localStorage went away. No data integrity risk; only a
+  small UX nuisance.
+- **Phase 4 consent ledger migration writes nothing pre-Phase 4.**
+  The 7-year audit retention clock does NOT start until Phase 4.
+  Demos and internal use run with only the localStorage record —
+  acceptable for demo horizon, blocker for any customer onboarding
+  where auditable consent trail is a contract requirement.
+
+## Related
+
+- ARCHITECTURE.md §9.3 Consent Capture — the mandate this ADR
+  concretizes into Phase 3c code.
+- ADR-0012 Remove voiceprint matching — why there is no biometric
+  consent; this ADR handles only audio-processing + transcript
+  consent.
+- ADR-0022 Cloud multi-tenancy isolation — Phase 4 sibling, same
+  Cognito-wiring trigger.
+- ADR-0023 Demo-horizon defaults — same two-phase-decision pattern
+  (demo now + Phase 4 migration trigger).
+- GDPR Art. 6(1)(f), Art. 9(2)(a), Art. 4(1).
+- BIPA (Illinois), CCPA (California), state wiretap statutes —
+  jurisdictional surface the export consent modal transfers
+  responsibility for.

--- a/frontend_web/src/components/AudioProcessingConsent.tsx
+++ b/frontend_web/src/components/AudioProcessingConsent.tsx
@@ -1,0 +1,80 @@
+// frontend_web/src/components/AudioProcessingConsent.tsx
+//
+// The ARCH §9.3 / ADR-0024 Decision A one-time audio-processing
+// consent gate. Mount on the signed-in Host page; checks localStorage
+// on every render; prompts if no acceptance record exists for the
+// current user at the current policy version. No decline path —
+// consent is required to use the app, so refusing just leaves the
+// modal open (user can close the tab).
+
+import { useEffect, useState, type JSX } from "react";
+
+import {
+  CURRENT_POLICY_VERSION,
+  hasAudioProcessingConsent,
+  recordAudioProcessingConsent,
+} from "@/lib/consent";
+
+import { ConsentModal } from "./ConsentModal";
+
+export interface AudioProcessingConsentProps {
+  /** The signed-in user's stable identifier. */
+  readonly userId: string;
+  /**
+   * Optional callback invoked once after consent has been recorded.
+   * Useful if the parent wants to show a toast / kick off a post-
+   * consent action. Not required; the modal closes itself.
+   */
+  readonly onAccepted?: () => void;
+}
+
+export function AudioProcessingConsent(
+  props: AudioProcessingConsentProps,
+): JSX.Element | null {
+  const { userId, onAccepted } = props;
+  // Lazy initial state: synchronous localStorage read on mount so the
+  // modal never flashes for users who already accepted.
+  const [needed, setNeeded] = useState<boolean>(
+    () => !hasAudioProcessingConsent(userId, CURRENT_POLICY_VERSION),
+  );
+
+  // Re-check when the userId changes (sign-out → sign-in as a
+  // different account). The consent is per-user so the new principal
+  // must grant fresh.
+  useEffect(() => {
+    setNeeded(!hasAudioProcessingConsent(userId, CURRENT_POLICY_VERSION));
+  }, [userId]);
+
+  const handleAccept = () => {
+    recordAudioProcessingConsent(userId, CURRENT_POLICY_VERSION);
+    setNeeded(false);
+    onAccepted?.();
+  };
+
+  return (
+    <ConsentModal
+      open={needed}
+      title="Audio processing consent"
+      acceptLabel="Agree"
+      closable={false}
+      onAccept={handleAccept}
+    >
+      {/*
+        ARCH §9.3 copy verbatim. When this prose materially changes,
+        bump CURRENT_POLICY_VERSION in lib/consent.ts so existing
+        users re-accept the new terms.
+      */}
+      <p>
+        Aegis transcribes your meeting audio in real time and generates
+        suggestion hints from a knowledge corpus you select. Audio is processed
+        only in memory and is never saved.
+      </p>
+      <p style={{ fontSize: "0.85rem", color: "#666" }}>
+        Your acceptance is recorded with your user identifier, policy version (
+        <code>{CURRENT_POLICY_VERSION}</code>), the current timestamp, and your
+        browser identifier. See ARCHITECTURE.md §9.3 and ADR-0024 for details on
+        the consent ledger.
+      </p>
+    </ConsentModal>
+  );
+}

--- a/frontend_web/src/components/ConsentModal.tsx
+++ b/frontend_web/src/components/ConsentModal.tsx
@@ -1,0 +1,144 @@
+// frontend_web/src/components/ConsentModal.tsx
+//
+// Reusable modal shell for the consent flows defined in ADR-0024.
+// Intentionally bare-bones visually — the copy is what matters. Three
+// buttons: primary accept, optional secondary decline, optional
+// dismiss-by-close (set via `closable`).
+//
+// Uses a <dialog> element with the native modal behavior (showModal /
+// close), which gets us ESC-to-close + focus-trap + backdrop click for
+// free across every target WebView (Chrome / Edge / WKWebView per
+// ADR-0002 Constraint 4). No library dependency.
+
+import { useEffect, useRef, type JSX, type ReactNode } from "react";
+
+export interface ConsentModalProps {
+  /** Controls whether the dialog is open. */
+  readonly open: boolean;
+  /** Title rendered at the top of the modal. */
+  readonly title: string;
+  /** Rich body — caller assembles prose, links, bullet points. */
+  readonly children: ReactNode;
+  /** Label for the primary accept button (e.g. "Agree", "Confirm export"). */
+  readonly acceptLabel: string;
+  /** Optional decline / cancel button. Omit to force accept-only flow. */
+  readonly declineLabel?: string;
+  /** Invoked when the user clicks the primary accept button. */
+  readonly onAccept: () => void;
+  /** Invoked on decline click or (if `closable`) on dismiss. */
+  readonly onDecline?: () => void;
+  /**
+   * When true, ESC key and backdrop click dismiss the modal (calling
+   * `onDecline` if provided). When false, the user can only progress
+   * by clicking an explicit button — the pattern for the
+   * audio-processing one-time gate which has no decline path.
+   */
+  readonly closable?: boolean;
+}
+
+export function ConsentModal(props: ConsentModalProps): JSX.Element | null {
+  const {
+    open,
+    title,
+    children,
+    acceptLabel,
+    declineLabel,
+    onAccept,
+    onDecline,
+    closable = true,
+  } = props;
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+
+  // Drive the underlying <dialog> element's imperative open/close from
+  // the `open` prop. Using showModal() rather than the `open` attribute
+  // so we get focus-trap + scroll-lock + backdrop.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog === null) return;
+    if (open && !dialog.open) {
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  // When `closable` is false, intercept ESC + backdrop click. The
+  // <dialog> element's default cancel event is what ESC triggers.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog === null) return;
+    const onCancel = (e: Event) => {
+      if (!closable) {
+        e.preventDefault();
+        return;
+      }
+      onDecline?.();
+    };
+    dialog.addEventListener("cancel", onCancel);
+    return () => dialog.removeEventListener("cancel", onCancel);
+  }, [closable, onDecline]);
+
+  if (!open) {
+    // Keep the dialog element mounted so refs stay stable; the effect
+    // above drives its open/close state.
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="consent-modal-title"
+      style={{
+        border: "1px solid #ccc",
+        borderRadius: "8px",
+        padding: "1.5rem",
+        maxWidth: "540px",
+        fontFamily: "system-ui, sans-serif",
+        lineHeight: 1.5,
+      }}
+    >
+      <h2
+        id="consent-modal-title"
+        style={{ marginTop: 0, marginBottom: "1rem", fontSize: "1.1rem" }}
+      >
+        {title}
+      </h2>
+      <div style={{ marginBottom: "1.25rem", fontSize: "0.95rem" }}>
+        {children}
+      </div>
+      <div
+        style={{ display: "flex", gap: "0.5rem", justifyContent: "flex-end" }}
+      >
+        {declineLabel !== undefined ? (
+          <button
+            type="button"
+            onClick={() => onDecline?.()}
+            style={{
+              padding: "0.4rem 0.9rem",
+              border: "1px solid #ccc",
+              borderRadius: "4px",
+              background: "white",
+              cursor: "pointer",
+            }}
+          >
+            {declineLabel}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={onAccept}
+          autoFocus
+          style={{
+            padding: "0.4rem 0.9rem",
+            border: "1px solid #0d6efd",
+            borderRadius: "4px",
+            background: "#0d6efd",
+            color: "white",
+            cursor: "pointer",
+          }}
+        >
+          {acceptLabel}
+        </button>
+      </div>
+    </dialog>
+  );
+}

--- a/frontend_web/src/components/TranscriptExportConsentModal.tsx
+++ b/frontend_web/src/components/TranscriptExportConsentModal.tsx
@@ -1,0 +1,102 @@
+// frontend_web/src/components/TranscriptExportConsentModal.tsx
+//
+// Phase 2 of the transcript consent flow per ADR-0024 Decision C.
+// Shown before every transcript export; caller supplies user / session
+// context and an `onConfirm` callback that receives the confirmed
+// export-format choice. This component does NOT perform the export
+// itself — Slice 5 wires the export action into the `onConfirm`
+// callback. The audit record is emitted here.
+
+import { useState, type JSX } from "react";
+
+import { recordTranscriptExportConsent } from "@/lib/consent";
+
+import { ConsentModal } from "./ConsentModal";
+
+export type TranscriptExportFormat = "markdown" | "json";
+
+export interface TranscriptExportConsentModalProps {
+  readonly open: boolean;
+  /** The signed-in user's stable identifier. */
+  readonly userId: string;
+  /** The active meeting's session identifier. */
+  readonly sessionId: string;
+  /** Invoked on confirm with the chosen export format. */
+  readonly onConfirm: (format: TranscriptExportFormat) => void;
+  /** Invoked on cancel / dismiss. */
+  readonly onCancel: () => void;
+}
+
+export function TranscriptExportConsentModal(
+  props: TranscriptExportConsentModalProps,
+): JSX.Element {
+  const { open, userId, sessionId, onConfirm, onCancel } = props;
+  const [format, setFormat] = useState<TranscriptExportFormat>("markdown");
+
+  const handleAccept = () => {
+    recordTranscriptExportConsent(userId, sessionId, format);
+    onConfirm(format);
+  };
+
+  return (
+    <ConsentModal
+      open={open}
+      title="Export transcript — responsibility transfer"
+      acceptLabel="Confirm export"
+      declineLabel="Cancel"
+      closable={true}
+      onAccept={handleAccept}
+      onDecline={onCancel}
+    >
+      <p>
+        You are about to save the meeting transcript to a file. By proceeding,
+        you confirm that:
+      </p>
+      <ul style={{ paddingLeft: "1.2rem", margin: "0.5rem 0 1rem" }}>
+        <li>
+          You are responsible for the transcript file under your jurisdiction's
+          data-protection laws from this moment forward.
+        </li>
+        <li>
+          You will not share the file with anyone not authorized to see this
+          meeting's contents.
+        </li>
+        <li>
+          This action is recorded in the consent ledger with your user ID,
+          session ID, timestamp, and client metadata.
+        </li>
+      </ul>
+      <fieldset
+        style={{
+          border: "1px solid #ddd",
+          padding: "0.6rem",
+          margin: "0.5rem 0",
+        }}
+      >
+        <legend style={{ padding: "0 0.4rem", fontSize: "0.85rem" }}>
+          Export format
+        </legend>
+        <label style={{ marginRight: "1rem" }}>
+          <input
+            type="radio"
+            name="export-format"
+            value="markdown"
+            checked={format === "markdown"}
+            onChange={() => setFormat("markdown")}
+          />{" "}
+          Markdown (<code>.md</code>)
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="export-format"
+            value="json"
+            checked={format === "json"}
+            onChange={() => setFormat("json")}
+          />{" "}
+          JSON
+        </label>
+      </fieldset>
+    </ConsentModal>
+  );
+}

--- a/frontend_web/src/lib/consent.ts
+++ b/frontend_web/src/lib/consent.ts
@@ -1,0 +1,151 @@
+// frontend_web/src/lib/consent.ts
+//
+// Consent-record persistence + audit-log emission helpers per
+// ADR-0024 (Consent flows — audio-processing + transcript 2-phase).
+//
+// Phase 3 demo horizon: audio-processing consent is localStorage-
+// persisted per policy version; transcript-export consent fires
+// an audit record via `console.info` and the future Phase 4 wiring
+// drops in a gateway `LogConsentEvent` RPC at the same emit-point.
+// The consent-record SHAPE is stable across the Phase 3 → Phase 4
+// migration so no caller code changes when the wire path moves.
+
+/**
+ * Privacy-policy version. Bump when the copy in
+ * `AudioProcessingConsent.tsx` materially changes; bumping invalidates
+ * previously-stored acceptance records (the key changes from
+ * `aegis.consent.audio_processing.v1` to `…v2`), forcing the user to
+ * consent to the new terms.
+ */
+export const CURRENT_POLICY_VERSION = "v1" as const;
+export type PolicyVersion = typeof CURRENT_POLICY_VERSION;
+
+const AUDIO_CONSENT_KEY_PREFIX = "aegis.consent.audio_processing.";
+
+/**
+ * A consent record written at acceptance time. Shape is load-bearing
+ * across the Phase 3 → Phase 4 migration: the same structure is what
+ * the Phase 4 gateway's DynamoDB consent-ledger row will accept.
+ */
+export interface AudioProcessingConsentRecord {
+  readonly kind: "consent:audio_processing:accepted";
+  readonly userId: string;
+  readonly policyVersion: PolicyVersion;
+  readonly acceptedAt: string; // ISO 8601 UTC
+  readonly clientMetadata: {
+    readonly userAgent: string;
+    readonly deployMode: string;
+  };
+}
+
+export interface TranscriptExportConsentRecord {
+  readonly kind: "consent:transcript:export:confirmed";
+  readonly userId: string;
+  readonly sessionId: string;
+  readonly exportFormat: "markdown" | "json";
+  readonly exportedAt: string; // ISO 8601 UTC
+  readonly clientMetadata: {
+    readonly userAgent: string;
+    readonly deployMode: string;
+  };
+}
+
+function clientMetadata(): {
+  readonly userAgent: string;
+  readonly deployMode: string;
+} {
+  return {
+    userAgent:
+      typeof navigator !== "undefined" ? navigator.userAgent : "unknown",
+    deployMode:
+      (import.meta.env["VITE_AEGIS_DEPLOY_MODE"] as string | undefined) ??
+      "local",
+  };
+}
+
+/**
+ * Check whether the current user has already accepted the audio-
+ * processing consent at the current policy version. Cheap, synchronous,
+ * safe to call from a React effect.
+ */
+export function hasAudioProcessingConsent(
+  userId: string,
+  policyVersion: PolicyVersion = CURRENT_POLICY_VERSION,
+): boolean {
+  if (typeof localStorage === "undefined") return false;
+  const key = AUDIO_CONSENT_KEY_PREFIX + policyVersion;
+  const raw = localStorage.getItem(key);
+  if (raw === null) return false;
+  try {
+    const parsed = JSON.parse(raw) as AudioProcessingConsentRecord;
+    return parsed.userId === userId && parsed.policyVersion === policyVersion;
+  } catch {
+    // Corrupt record — treat as absent; the user re-accepts.
+    return false;
+  }
+}
+
+/**
+ * Record audio-processing consent acceptance for the current user.
+ * Writes to localStorage (Phase 3) and emits via `console.info` so the
+ * Phase 4 gateway RPC drop-in sees a compatible record shape.
+ */
+export function recordAudioProcessingConsent(
+  userId: string,
+  policyVersion: PolicyVersion = CURRENT_POLICY_VERSION,
+): AudioProcessingConsentRecord {
+  const record: AudioProcessingConsentRecord = {
+    kind: "consent:audio_processing:accepted",
+    userId,
+    policyVersion,
+    acceptedAt: new Date().toISOString(),
+    clientMetadata: clientMetadata(),
+  };
+  if (typeof localStorage !== "undefined") {
+    const key = AUDIO_CONSENT_KEY_PREFIX + policyVersion;
+    try {
+      localStorage.setItem(key, JSON.stringify(record));
+    } catch {
+      // Quota / private-mode storage failure: surface via the audit
+      // emit below but do not throw — the user has still consented
+      // for this session; the localStorage gate will re-ask next
+      // visit, which is acceptable.
+    }
+  }
+  emitConsentEvent(record);
+  return record;
+}
+
+/**
+ * Record transcript-export consent confirmation. Slice 5 wires this
+ * into the actual export button; Slice 3 ships the helper so the
+ * export flow has one place to call.
+ */
+export function recordTranscriptExportConsent(
+  userId: string,
+  sessionId: string,
+  exportFormat: "markdown" | "json",
+): TranscriptExportConsentRecord {
+  const record: TranscriptExportConsentRecord = {
+    kind: "consent:transcript:export:confirmed",
+    userId,
+    sessionId,
+    exportFormat,
+    exportedAt: new Date().toISOString(),
+    clientMetadata: clientMetadata(),
+  };
+  emitConsentEvent(record);
+  return record;
+}
+
+/**
+ * Internal audit emit. Phase 3: `console.info`. Phase 4: replace with
+ * a gateway `LogConsentEvent` RPC call; the record shape is stable so
+ * no call-site churn.
+ */
+function emitConsentEvent(
+  record: AudioProcessingConsentRecord | TranscriptExportConsentRecord,
+): void {
+  // eslint-disable-next-line no-console
+  console.info("[aegis.consent]", record);
+}

--- a/frontend_web/src/pages/Host/HostPage.tsx
+++ b/frontend_web/src/pages/Host/HostPage.tsx
@@ -47,6 +47,7 @@ import {
 } from "react";
 import { QRCodeSVG } from "qrcode.react";
 
+import { AudioProcessingConsent } from "@/components/AudioProcessingConsent";
 import { gatewayClient } from "@/lib/gateway-client";
 import { auth } from "@/lib/auth";
 import {
@@ -120,6 +121,13 @@ interface ActiveMeeting {
   readonly subscription: Subscription;
   /** Rolling tail of transcript lines (oldest first). */
   readonly transcript: readonly TranscriptLine[];
+  /**
+   * Client-side render gate per ADR-0024 Decision B — true if the
+   * host explicitly opted into seeing the live transcript on this
+   * device for this meeting. Backend keeps transcribing regardless;
+   * this flag only controls what the host's browser renders.
+   */
+  readonly showTranscriptPanel: boolean;
 }
 
 interface TranscriptLine {
@@ -132,8 +140,19 @@ interface TranscriptLine {
 type HostState =
   | { kind: "loading-auth" }
   | { kind: "signed-out" }
-  | { kind: "ready"; principal: AuthPrincipal; ragId: string; title: string }
-  | { kind: "creating"; principal: AuthPrincipal }
+  | {
+      kind: "ready";
+      principal: AuthPrincipal;
+      ragId: string;
+      title: string;
+      /** Default OFF per ADR-0024 Decision B. Carried into ActiveMeeting on start. */
+      showTranscriptPanel: boolean;
+    }
+  | {
+      kind: "creating";
+      principal: AuthPrincipal;
+      showTranscriptPanel: boolean;
+    }
   | { kind: "active"; principal: AuthPrincipal; meeting: ActiveMeeting }
   | { kind: "ending"; principal: AuthPrincipal; meeting: ActiveMeeting }
   | { kind: "error"; principal: AuthPrincipal | null; message: string };
@@ -141,10 +160,14 @@ type HostState =
 type Action =
   | { type: "AUTH_RESOLVED"; principal: AuthPrincipal | null }
   | { type: "FORM_FIELD_CHANGED"; field: "ragId" | "title"; value: string }
+  | { type: "TRANSCRIPT_PANEL_TOGGLED"; value: boolean }
   | { type: "CREATE_REQUESTED" }
   | {
       type: "MEETING_STARTED";
-      meeting: Omit<ActiveMeeting, "transcript">;
+      // `showTranscriptPanel` comes from `state.showTranscriptPanel`
+      // (carried through `creating`), not from the action payload —
+      // the reducer wires it in on transition.
+      meeting: Omit<ActiveMeeting, "transcript" | "showTranscriptPanel">;
     }
   | { type: "TRANSCRIPT_LINE"; line: TranscriptLine }
   | { type: "END_REQUESTED" }
@@ -161,22 +184,35 @@ function reducer(state: HostState, action: Action): HostState {
         principal: action.principal,
         ragId: DEFAULT_RAG_ID,
         title: "",
+        showTranscriptPanel: false, // ADR-0024 Decision B: default OFF
       };
     }
     case "FORM_FIELD_CHANGED": {
       if (state.kind !== "ready") return state;
       return { ...state, [action.field]: action.value };
     }
+    case "TRANSCRIPT_PANEL_TOGGLED": {
+      if (state.kind !== "ready") return state;
+      return { ...state, showTranscriptPanel: action.value };
+    }
     case "CREATE_REQUESTED": {
       if (state.kind !== "ready") return state;
-      return { kind: "creating", principal: state.principal };
+      return {
+        kind: "creating",
+        principal: state.principal,
+        showTranscriptPanel: state.showTranscriptPanel,
+      };
     }
     case "MEETING_STARTED": {
       if (state.kind !== "creating") return state;
       return {
         kind: "active",
         principal: state.principal,
-        meeting: { ...action.meeting, transcript: [] },
+        meeting: {
+          ...action.meeting,
+          transcript: [],
+          showTranscriptPanel: state.showTranscriptPanel,
+        },
       };
     }
     case "TRANSCRIPT_LINE": {
@@ -215,7 +251,13 @@ function reducer(state: HostState, action: Action): HostState {
             ? state.principal
             : null;
       if (principal === null) return { kind: "signed-out" };
-      return { kind: "ready", principal, ragId: "", title: "" };
+      return {
+        kind: "ready",
+        principal,
+        ragId: "",
+        title: "",
+        showTranscriptPanel: false,
+      };
     }
     case "ERROR_RAISED": {
       // Carry forward the principal if we have one so the user lands
@@ -231,6 +273,7 @@ function reducer(state: HostState, action: Action): HostState {
         principal: state.principal,
         ragId: "",
         title: "",
+        showTranscriptPanel: false,
       };
     }
   }
@@ -479,9 +522,11 @@ export function HostPage(): JSX.Element {
     const isCreating = state.kind === "creating";
     const ragId = state.kind === "ready" ? state.ragId : DEFAULT_RAG_ID;
     const title = state.kind === "ready" ? state.title : "";
+    const showTranscriptPanel = state.showTranscriptPanel;
     return (
       <main>
         <Header principal={state.principal} />
+        <AudioProcessingConsent userId={state.principal.userId} />
         <h3>Start a new meeting</h3>
         <form
           onSubmit={(e) => {
@@ -528,6 +573,47 @@ export function HostPage(): JSX.Element {
               }
             />
           </label>
+
+          {/*
+            Transcript panel opt-in (ADR-0024 Decision B). Default
+            OFF. Turning ON shows the GDPR notice so the host
+            acknowledges the on-screen-data-exposure risk before the
+            transcript renders live.
+          */}
+          <fieldset disabled={isCreating} style={{ marginBottom: "1rem" }}>
+            <legend>Live transcript panel</legend>
+            <label style={{ display: "block", marginBottom: "0.25rem" }}>
+              <input
+                type="checkbox"
+                checked={showTranscriptPanel}
+                onChange={(e) =>
+                  dispatch({
+                    type: "TRANSCRIPT_PANEL_TOGGLED",
+                    value: e.target.checked,
+                  })
+                }
+              />{" "}
+              Show live transcript on this screen
+            </label>
+            {showTranscriptPanel && (
+              <p
+                style={{
+                  margin: "0.3rem 0 0 1.6rem",
+                  fontSize: "0.82rem",
+                  color: "#555",
+                  maxWidth: "44rem",
+                }}
+              >
+                Turning on the live transcript shows meeting content on your
+                screen. Aegis processes this data under GDPR Art. 6(1)(f)
+                (legitimate interests — operating the service you requested)
+                and, where participants' messages include special-category data,
+                Art. 9(2)(a) (your explicit consent to see it). You are
+                responsible for the physical security of your screen
+                (bystanders, recording devices) while the panel is visible.
+              </p>
+            )}
+          </fieldset>
 
           <fieldset disabled={isCreating} style={{ marginBottom: "1rem" }}>
             <legend>Audio source</legend>
@@ -595,6 +681,7 @@ export function HostPage(): JSX.Element {
   return (
     <main>
       <Header principal={state.principal} />
+      <AudioProcessingConsent userId={state.principal.userId} />
       <h3>Meeting active</h3>
 
       <section
@@ -641,7 +728,22 @@ export function HostPage(): JSX.Element {
             state: <code>{meeting.peer.connectionState}</code>
           </p>
           <h4 style={{ marginBottom: "0.25rem" }}>Live transcript (echo)</h4>
-          {meeting.transcript.length === 0 ? (
+          {/*
+            ADR-0024 Decision B render gate. When the host did not opt
+            in to the panel, we show a placeholder instead of the
+            transcript lines. The backend keeps transcribing either
+            way — this is purely a client-side visibility choice.
+            ADR-0024 Decision D also forbids disabling text selection
+            on the transcript (screenshots bypass it, breaks screen
+            readers); the compliance script enforces that rule.
+          */}
+          {!meeting.showTranscriptPanel ? (
+            <p style={{ color: "#888", fontStyle: "italic" }}>
+              Transcript display disabled for this meeting. Toggle on in the New
+              Meeting form to show transcript lines on this screen (default OFF
+              per consent posture).
+            </p>
+          ) : meeting.transcript.length === 0 ? (
             <p style={{ color: "#888", fontStyle: "italic" }}>
               Waiting for the first segment…
             </p>

--- a/tools/scripts/check_frontend_tauri_compliance.sh
+++ b/tools/scripts/check_frontend_tauri_compliance.sh
@@ -123,6 +123,14 @@ check "Constraint 5 (Blob downloads only via FileSystemProvider)" \
   '\.download = ' \
   '/FileSystemProvider/'
 
+# ADR-0024 Decision D — transcript text must never have
+# `user-select: none`. The CSS rule provides theatrical protection
+# (screenshots bypass it) at real accessibility cost (breaks screen
+# readers). The forbidden pattern appears in both CSS-string form
+# and the React inline-style-object form.
+check "ADR-0024 D (no user-select: none on transcript text)" \
+  'user-select:\s*none|userSelect:\s*["'"'"']none["'"'"']'
+
 # Constraint 6 — informational warning only; IndexedDB is permitted
 # but large-binary storage is not. Flag for reviewer attention.
 INDEXEDDB="$(grep -RInE --include='*.ts' --include='*.tsx' \


### PR DESCRIPTION
## Summary

Implements ADR-0024 consent flows for Phase 3 demo horizon. Two-part consent model per ARCH §9.3 / ADR-0024:

- **Audio processing** (Decision A): one-time, per user × policy version, localStorage-persisted, no-decline gate. Mounts on signed-in Host page.
- **Transcript panel** (Decision B): opt-in per meeting, default OFF, GDPR Art. 6(1)(f) + 9(2)(a) notice in the New Meeting form.
- **Transcript export** (Decision C): phase-2 modal with Markdown/JSON format selector; audit record emitted via `console.info` (Phase 4 gateway `LogConsentEvent` RPC drop-in — record shape is stable).
- **No `user-select: none`** on transcript text (Decision D): screenshots bypass the lock and it breaks screen readers. Enforced by compliance grep.
- **Watermarking** (Decision E): deferred to Phase 4+.

## Files

- `docs/adr/0024-consent-flows-audio-and-transcript.md` (new)
- `frontend_web/src/lib/consent.ts` (new) — record shapes + localStorage helpers + audit emit
- `frontend_web/src/components/ConsentModal.tsx` (new) — reusable `<dialog>` shell
- `frontend_web/src/components/AudioProcessingConsent.tsx` (new) — one-time gate
- `frontend_web/src/components/TranscriptExportConsentModal.tsx` (new) — phase-2 modal (Slice 5 wires it)
- `frontend_web/src/pages/Host/HostPage.tsx` — `showTranscriptPanel` in state, checkbox, consent gate mount
- `tools/scripts/check_frontend_tauri_compliance.sh` — extended with ADR-0024 D rule

## Test plan

- [x] `./tools/scripts/frontend.sh typecheck` green
- [x] `./tools/scripts/frontend.sh build` green (180 modules)
- [x] `./tools/scripts/check_frontend_tauri_compliance.sh` green (0 violations including new D rule)
- [ ] CI 7-job matrix green
- [ ] Admin merge after CI green (solo repo, GitHub blocks self-approval)