### PR TITLE
Phase 3c Slice 5 — transcript export (MD + JSON via FileSystemProvider)

### DIFF
--- a/frontend_web/src/lib/transcriptExport.ts
+++ b/frontend_web/src/lib/transcriptExport.ts
@@ -1,0 +1,114 @@
+// frontend_web/src/lib/transcriptExport.ts
+//
+// Pure formatting helpers for the transcript-export flow (ADR-0024
+// Decision C, wired to the export button in Phase 3c Slice 5). No
+// DOM / fetch / console — given a transcript + meeting metadata,
+// produce a UTF-8 string the FileSystemProvider can hand to the OS
+// save dialog. Speaker overrides (ARCH §9.2) are resolved here so
+// the file reflects what the host saw on screen.
+
+export interface TranscriptSegment {
+  readonly id: string;
+  readonly text: string;
+  readonly isFinal: boolean;
+  readonly speaker: string;
+}
+
+export interface TranscriptExportMeta {
+  readonly sessionId: string;
+  readonly userId: string;
+  readonly title: string;
+  readonly exportedAt: string; // ISO 8601 UTC
+}
+
+function resolveLabel(
+  segment: TranscriptSegment,
+  overrides: Readonly<Record<string, string>>,
+): string {
+  return overrides[segment.speaker] ?? segment.speaker;
+}
+
+/**
+ * Filename suggestion — ISO date + sanitised title. Keeps the
+ * suggestion OS-safe (no `/`, no control chars) so the Web impl's
+ * anchor-download and the future Tauri `rfd::FileDialog` both
+ * accept it without further munging.
+ */
+export function suggestedFilename(
+  meta: TranscriptExportMeta,
+  extension: "md" | "json",
+): string {
+  const datePart = meta.exportedAt.slice(0, 10); // "YYYY-MM-DD"
+  const titlePart =
+    meta.title.trim() === ""
+      ? meta.sessionId
+      : meta.title
+          .trim()
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "")
+          .slice(0, 48);
+  return `aegis-transcript-${datePart}-${
+    titlePart || meta.sessionId
+  }.${extension}`;
+}
+
+/**
+ * Markdown export. Final segments are rendered normally; interim
+ * segments are marked with a trailing `(interim)` tag so downstream
+ * readers can tell which lines were mid-stream approximations.
+ */
+export function formatTranscriptMarkdown(
+  transcript: readonly TranscriptSegment[],
+  overrides: Readonly<Record<string, string>>,
+  meta: TranscriptExportMeta,
+): string {
+  const header = [
+    `# Aegis meeting transcript`,
+    ``,
+    `- **Session**: \`${meta.sessionId}\``,
+    `- **Title**: ${meta.title.trim() === "" ? "_(untitled)_" : meta.title}`,
+    `- **Host**: \`${meta.userId}\``,
+    `- **Exported**: ${meta.exportedAt}`,
+    ``,
+    `> Transcripts are the host's responsibility to store and share`,
+    `> under applicable data-protection law (ADR-0024 Decision C).`,
+    ``,
+    `---`,
+    ``,
+  ].join("\n");
+  const lines = transcript.map((seg) => {
+    const label = resolveLabel(seg, overrides);
+    const tail = seg.isFinal ? "" : " _(interim)_";
+    return `- **${label}**: ${seg.text}${tail}`;
+  });
+  return header + lines.join("\n") + "\n";
+}
+
+/**
+ * JSON export. Stable machine-readable shape — intentionally a flat
+ * envelope so downstream tooling can parse without schema reflection.
+ * Speaker overrides are materialised into `speakerDisplay` so a
+ * consumer who doesn't know the override-map semantics still gets
+ * the label the host meant.
+ */
+export function formatTranscriptJson(
+  transcript: readonly TranscriptSegment[],
+  overrides: Readonly<Record<string, string>>,
+  meta: TranscriptExportMeta,
+): string {
+  const envelope = {
+    kind: "aegis.transcript.export" as const,
+    schemaVersion: 1 as const,
+    meta,
+    speakerOverrides: overrides,
+    segments: transcript.map((seg) => ({
+      id: seg.id,
+      text: seg.text,
+      isFinal: seg.isFinal,
+      speakerDetected: seg.speaker,
+      speakerDisplay: resolveLabel(seg, overrides),
+    })),
+  };
+  return JSON.stringify(envelope, null, 2) + "\n";
+}

--- a/frontend_web/src/pages/Host/HostPage.tsx
+++ b/frontend_web/src/pages/Host/HostPage.tsx
@@ -48,8 +48,18 @@ import {
 import { QRCodeSVG } from "qrcode.react";
 
 import { AudioProcessingConsent } from "@/components/AudioProcessingConsent";
+import {
+  TranscriptExportConsentModal,
+  type TranscriptExportFormat,
+} from "@/components/TranscriptExportConsentModal";
 import { gatewayClient } from "@/lib/gateway-client";
 import { auth } from "@/lib/auth";
+import {
+  formatTranscriptJson,
+  formatTranscriptMarkdown,
+  suggestedFilename,
+  type TranscriptExportMeta,
+} from "@/lib/transcriptExport";
 import {
   CaptureError,
   type CaptureMode,
@@ -57,6 +67,10 @@ import {
   WebAudioCaptureProvider,
 } from "@/providers/AudioCaptureProvider";
 import type { AuthPrincipal } from "@/providers/AuthProvider";
+import {
+  pickFileSystemProvider,
+  type FileSystemProvider,
+} from "@/providers/FileSystemProvider";
 import {
   pickTranscriptStreamProvider,
   type Subscription,
@@ -138,7 +152,11 @@ interface ActiveMeeting {
   readonly capture: CaptureSession;
   readonly peer: RTCPeerConnection;
   readonly subscription: Subscription;
-  /** Rolling tail of transcript lines (oldest first). */
+  /** Host-chosen meeting title (free-text, not PII-sensitive). Used
+   *  in export metadata + filename suggestion. Empty string allowed. */
+  readonly title: string;
+  /** Full accumulated transcript (not trimmed). Display uses the
+   *  tail slice. Export uses the full array per ARCH §9.1. */
   readonly transcript: readonly TranscriptLine[];
   /**
    * Client-side render gate per ADR-0024 Decision B — true if the
@@ -179,6 +197,7 @@ type HostState =
   | {
       kind: "creating";
       principal: AuthPrincipal;
+      title: string;
       showTranscriptPanel: boolean;
     }
   | { kind: "active"; principal: AuthPrincipal; meeting: ActiveMeeting }
@@ -197,7 +216,7 @@ type Action =
       // the reducer wires it in on transition.
       meeting: Omit<
         ActiveMeeting,
-        "transcript" | "showTranscriptPanel" | "speakerOverrides"
+        "transcript" | "showTranscriptPanel" | "speakerOverrides" | "title"
       >;
     }
   | { type: "TRANSCRIPT_LINE"; line: TranscriptLine }
@@ -237,6 +256,7 @@ function reducer(state: HostState, action: Action): HostState {
       return {
         kind: "creating",
         principal: state.principal,
+        title: state.title,
         showTranscriptPanel: state.showTranscriptPanel,
       };
     }
@@ -247,6 +267,7 @@ function reducer(state: HostState, action: Action): HostState {
         principal: state.principal,
         meeting: {
           ...action.meeting,
+          title: state.title,
           transcript: [],
           showTranscriptPanel: state.showTranscriptPanel,
           speakerOverrides: {},
@@ -259,18 +280,20 @@ function reducer(state: HostState, action: Action): HostState {
       // overwritten by its final form. The id contains isFinal so
       // a finalized version naturally has a different key — handle
       // that by pruning prior interims of the same numeric segmentId.
+      //
+      // The host accumulates the FULL transcript per ARCH §9.1
+      // (host-local accumulation, browser memory only). The display
+      // tail (TRANSCRIPT_TAIL) is applied at render time. Export in
+      // Slice 5 needs the full history; a 4-hour meeting at ~1 seg/s
+      // is a few MB of UTF-8 — fine for browser memory.
       const numericId = action.line.id.split(":")[0];
       const filtered = state.meeting.transcript.filter(
         (l) => l.id.split(":")[0] !== numericId,
       );
       const next = [...filtered, action.line];
-      const trimmed =
-        next.length > TRANSCRIPT_TAIL
-          ? next.slice(next.length - TRANSCRIPT_TAIL)
-          : next;
       return {
         ...state,
-        meeting: { ...state.meeting, transcript: trimmed },
+        meeting: { ...state.meeting, transcript: next },
       };
     }
     case "SPEAKER_LABEL_ASSIGNED": {
@@ -351,6 +374,16 @@ export function HostPage(): JSX.Element {
   // Single AudioCaptureProvider for the page. Stateless across
   // start/stop cycles; safe to memoize.
   const captureProvider = useMemo(() => new WebAudioCaptureProvider(), []);
+  // FileSystemProvider (ADR-0002 Constraint 5) for transcript export.
+  // Web impl wraps Blob + anchor download today; Phase 4 swap to Tauri.
+  const fileSystem: FileSystemProvider = useMemo(
+    () => pickFileSystemProvider(),
+    [],
+  );
+
+  // Export-flow UI state — purely visual, not in the reducer.
+  const [exportModalOpen, setExportModalOpen] = useState<boolean>(false);
+  const [exportError, setExportError] = useState<string | null>(null);
 
   // ──────────────────────────────────────────────────────────────────
   // Auth subscription. Local mode fires once with the synthetic
@@ -501,6 +534,50 @@ export function HostPage(): JSX.Element {
       }
     },
     [captureProvider],
+  );
+
+  // Export flow (ADR-0024 Decision C). The TranscriptExportConsentModal
+  // owns the acceptance gesture + audit record emit; this handler only
+  // runs once the user has confirmed. Formatting + save is synchronous
+  // enough (transcripts are at most a few MB of UTF-8) that a promise
+  // round-trip is fine without a spinner.
+  const performExport = useCallback(
+    async (format: TranscriptExportFormat, meeting: ActiveMeeting) => {
+      setExportError(null);
+      try {
+        const meta: TranscriptExportMeta = {
+          sessionId: meeting.sessionId,
+          userId:
+            state.kind === "active" || state.kind === "ending"
+              ? state.principal.userId
+              : "unknown",
+          title: meeting.title,
+          exportedAt: new Date().toISOString(),
+        };
+        const content =
+          format === "markdown"
+            ? formatTranscriptMarkdown(
+                meeting.transcript,
+                meeting.speakerOverrides,
+                meta,
+              )
+            : formatTranscriptJson(
+                meeting.transcript,
+                meeting.speakerOverrides,
+                meta,
+              );
+        const extension = format === "markdown" ? "md" : "json";
+        await fileSystem.saveAs({
+          suggestedName: suggestedFilename(meta, extension),
+          content,
+          format,
+        });
+        setExportModalOpen(false);
+      } catch (err) {
+        setExportError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [fileSystem, state],
   );
 
   const endMeeting = useCallback(async (active: ActiveMeeting) => {
@@ -820,36 +897,81 @@ export function HostPage(): JSX.Element {
                   })
                 }
               />
+              {/*
+                The transcript accumulates unbounded per ARCH §9.1 so
+                export can include the full history. Only the TAIL is
+                rendered on screen to match the Viewer-side
+                PROMPTER_WINDOW (5).
+              */}
               <ul style={{ paddingLeft: "1rem" }}>
-                {meeting.transcript.map((line) => {
-                  const displayLabel =
-                    meeting.speakerOverrides[line.speaker] ?? line.speaker;
-                  return (
-                    <li
-                      key={line.id}
-                      style={{
-                        color: line.isFinal ? "#000" : "#888",
-                        fontStyle: line.isFinal ? "normal" : "italic",
-                      }}
-                    >
-                      <strong>{displayLabel}:</strong> {line.text}
-                    </li>
-                  );
-                })}
+                {meeting.transcript
+                  .slice(
+                    Math.max(0, meeting.transcript.length - TRANSCRIPT_TAIL),
+                  )
+                  .map((line) => {
+                    const displayLabel =
+                      meeting.speakerOverrides[line.speaker] ?? line.speaker;
+                    return (
+                      <li
+                        key={line.id}
+                        style={{
+                          color: line.isFinal ? "#000" : "#888",
+                          fontStyle: line.isFinal ? "normal" : "italic",
+                        }}
+                      >
+                        <strong>{displayLabel}:</strong> {line.text}
+                      </li>
+                    );
+                  })}
               </ul>
+              {meeting.transcript.length > TRANSCRIPT_TAIL && (
+                <p style={{ fontSize: "0.75rem", color: "#888", margin: 0 }}>
+                  Showing the last {TRANSCRIPT_TAIL} lines ·{" "}
+                  {meeting.transcript.length} segments accumulated (full history
+                  exported on demand).
+                </p>
+              )}
             </>
           )}
 
-          <button
-            type="button"
-            onClick={() => void endMeeting(meeting)}
-            disabled={isEnding}
-            style={{ marginTop: "1rem" }}
-          >
-            {isEnding ? "Ending…" : "End meeting"}
-          </button>
+          <div style={{ marginTop: "1rem", display: "flex", gap: "0.5rem" }}>
+            <button
+              type="button"
+              onClick={() => {
+                setExportError(null);
+                setExportModalOpen(true);
+              }}
+              disabled={meeting.transcript.length === 0 || isEnding}
+              title={
+                meeting.transcript.length === 0
+                  ? "Nothing to export yet — wait for the first segment"
+                  : "Export the full transcript — consent modal opens first"
+              }
+            >
+              Export transcript…
+            </button>
+            <button
+              type="button"
+              onClick={() => void endMeeting(meeting)}
+              disabled={isEnding}
+            >
+              {isEnding ? "Ending…" : "End meeting"}
+            </button>
+          </div>
+          {exportError !== null && (
+            <p style={{ color: "#c0392b", fontSize: "0.85rem" }}>
+              Export failed: {exportError}
+            </p>
+          )}
         </div>
       </section>
+      <TranscriptExportConsentModal
+        open={exportModalOpen}
+        userId={state.principal.userId}
+        sessionId={meeting.sessionId}
+        onConfirm={(format) => void performExport(format, meeting)}
+        onCancel={() => setExportModalOpen(false)}
+      />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Wires ADR-0024 Decision C end-to-end: [Export transcript…] button → `TranscriptExportConsentModal` (Slice 3) → format (MD / JSON) → `fileSystem.saveAs(...)` via the FileSystemProvider port (ADR-0002 Constraint 5).

## Highlights

- New `lib/transcriptExport.ts` pure helpers: `formatTranscriptMarkdown`, `formatTranscriptJson`, `suggestedFilename`. No DOM/fetch/console.
- Speaker overrides (ARCH §9.2) resolved at format time — exported file matches what the host saw on screen.
- JSON envelope carries both `speakerDetected` and `speakerDisplay` so consumers without override-map knowledge get the right label.
- Reducer fix: `TRANSCRIPT_LINE` accumulates the full transcript per ARCH §9.1; the tail slice is now applied at render time only. Export needs full history, not 5 lines.
- `ActiveMeeting.title` carried from form → `creating` → `active`; drives export metadata + suggested filename.
- Tail counter UI: "Showing the last 5 lines · N segments accumulated" when the buffer exceeds the window.

## Files

- `frontend_web/src/lib/transcriptExport.ts` (new)
- `frontend_web/src/pages/Host/HostPage.tsx`

## Test plan

- [x] `./tools/scripts/frontend.sh typecheck` green
- [x] `./tools/scripts/frontend.sh build` green (184 modules)
- [x] `./tools/scripts/check_frontend_tauri_compliance.sh` green
- [ ] CI 7-job matrix green
- [ ] Admin merge after CI green (solo repo, GitHub blocks self-approval)