### PR TITLE
Phase 3c Slice 6 — Playwright live-browser smoke (Incident 09 prevention)

### DIFF
--- a/.github/workflows/ci-baseline.yml
+++ b/.github/workflows/ci-baseline.yml
@@ -275,16 +275,6 @@ jobs:
           restore-keys: |
             bazel-e2e-${{ runner.os }}-
 
-      # Fetch the Node toolchain explicitly with visible output — the
-      # frontend.sh wrapper quietly `|| true`s its own fetch on the
-      # assumption that the target already cached, which is not true
-      # on a cold CI runner. Doing it here makes any download failure
-      # observable instead of cascading into an opaque "node binary
-      # not found" from resolve_node_bin_dir.
-      - name: Fetch Bazel Node toolchain
-        run: |
-          ./tools/bazelisk/bazelisk build @rules_nodejs//nodejs:resolved_toolchain
-
       - name: Install frontend deps (hermetic pnpm)
         run: ./tools/scripts/frontend.sh install
 

--- a/.github/workflows/ci-baseline.yml
+++ b/.github/workflows/ci-baseline.yml
@@ -237,6 +237,62 @@ jobs:
         run: ./tools/scripts/check_frontend_tauri_compliance.sh
 
   # ---------------------------------------------------------------------------
+  # Live-browser smoke (Playwright) — Phase 3c Slice 6. Runs the frontend
+  # in real chromium + webkit engines via Playwright so UI-level
+  # regressions cannot hide behind jsdom approximations. Rooted in
+  # Incident 09's lesson: loopback/mock tests silently passed while
+  # every real-browser Opus frame failed to decode.
+  #
+  # Browsers are kept out of actions/cache at the global user dir;
+  # PLAYWRIGHT_BROWSERS_PATH is pinned to a repo-local path matching
+  # tools/scripts/frontend.sh so the cache key can live in-repo.
+  # ---------------------------------------------------------------------------
+  frontend-e2e-smoke:
+    name: Frontend live-browser smoke (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.playwright-browsers
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Cache Bazel (Node toolchain)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.bazel_cache
+            ${{ github.workspace }}/.bazelisk
+          key: bazel-e2e-${{ runner.os }}-${{ hashFiles('MODULE.bazel', '.bazelversion') }}
+          restore-keys: |
+            bazel-e2e-${{ runner.os }}-
+
+      - name: Install frontend deps (hermetic pnpm)
+        run: ./tools/scripts/frontend.sh install
+
+      - name: Install Playwright browsers
+        run: ./tools/scripts/frontend.sh e2e:install
+
+      - name: Run Playwright smoke
+        run: ./tools/scripts/frontend.sh e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend_web/playwright-report/
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
   # Documentation link check — basic sanity for internal cross-references.
   # Uses a lightweight action; does not fail the build on external link
   # timeouts (those are noisy).

--- a/.github/workflows/ci-baseline.yml
+++ b/.github/workflows/ci-baseline.yml
@@ -275,6 +275,16 @@ jobs:
           restore-keys: |
             bazel-e2e-${{ runner.os }}-
 
+      # Fetch the Node toolchain explicitly with visible output — the
+      # frontend.sh wrapper quietly `|| true`s its own fetch on the
+      # assumption that the target already cached, which is not true
+      # on a cold CI runner. Doing it here makes any download failure
+      # observable instead of cascading into an opaque "node binary
+      # not found" from resolve_node_bin_dir.
+      - name: Fetch Bazel Node toolchain
+        run: |
+          ./tools/bazelisk/bazelisk build @rules_nodejs//nodejs:resolved_toolchain
+
       - name: Install frontend deps (hermetic pnpm)
         run: ./tools/scripts/frontend.sh install
 

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,12 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+# Playwright browser binaries pinned to a repo-local directory via
+# PLAYWRIGHT_BROWSERS_PATH (tools/scripts/frontend.sh exports it).
+# Per-machine state, never committed.
+.playwright-browsers/
+frontend_web/playwright-report/
+frontend_web/test-results/
 
 # --- Go ------------------------------------------------------------------
 # Go modules live inside gateway_go/; we do NOT ignore go.sum.

--- a/frontend_web/e2e/consent-smoke.spec.ts
+++ b/frontend_web/e2e/consent-smoke.spec.ts
@@ -1,0 +1,80 @@
+// frontend_web/e2e/consent-smoke.spec.ts
+//
+// Phase 3c Slice 6 — live-browser acceptance for ADR-0024 Decisions
+// A and B. Runs in chromium + webkit (see playwright.config.ts) so
+// the native <dialog> element and focus-trap behaviour are exercised
+// in the real engines the app targets, not a jsdom approximation.
+
+import { expect, test } from "@playwright/test";
+
+test.describe("Audio processing consent — ADR-0024 Decision A", () => {
+  // Each test starts from a clean localStorage so the consent gate
+  // actually fires. The navigate-then-clear dance is necessary
+  // because localStorage is origin-scoped and can't be cleared
+  // before the first navigation.
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/host");
+    await page.evaluate(() => localStorage.clear());
+    await page.goto("/host");
+  });
+
+  test("modal appears on first visit and Agree dismisses it", async ({
+    page,
+  }) => {
+    const dialog = page.getByRole("dialog", {
+      name: /audio processing consent/i,
+    });
+    await expect(dialog).toBeVisible();
+    // ADR-0024 Decision A is an accept-only flow: no decline
+    // button, no ESC-to-close (closable={false}).
+    await expect(dialog.getByRole("button", { name: /agree/i })).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: /decline|cancel/i }),
+    ).toHaveCount(0);
+
+    await dialog.getByRole("button", { name: /agree/i }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test("accepted consent persists across reloads", async ({ page }) => {
+    const dialog = page.getByRole("dialog", {
+      name: /audio processing consent/i,
+    });
+    await dialog.getByRole("button", { name: /agree/i }).click();
+    await expect(dialog).toBeHidden();
+
+    await page.reload();
+    // The gate reads localStorage synchronously in `useState`'s
+    // initializer so the dialog must never be visible, not even for
+    // one paint.
+    await expect(dialog).toBeHidden();
+  });
+});
+
+test.describe("Transcript panel opt-in — ADR-0024 Decision B", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/host");
+    await page.evaluate(() => localStorage.clear());
+    await page.goto("/host");
+    // Dismiss the audio gate so the meeting form is reachable.
+    await page
+      .getByRole("dialog", { name: /audio processing consent/i })
+      .getByRole("button", { name: /agree/i })
+      .click();
+  });
+
+  test("transcript checkbox defaults OFF and reveals the GDPR notice when turned on", async ({
+    page,
+  }) => {
+    const checkbox = page.getByRole("checkbox", {
+      name: /show live transcript/i,
+    });
+    await expect(checkbox).toBeVisible();
+    await expect(checkbox).not.toBeChecked();
+
+    // GDPR notice should only appear after opt-in.
+    await expect(page.getByText(/GDPR Art\. 6\(1\)\(f\)/i)).toHaveCount(0);
+    await checkbox.check();
+    await expect(page.getByText(/GDPR Art\. 6\(1\)\(f\)/i)).toBeVisible();
+  });
+});

--- a/frontend_web/package.json
+++ b/frontend_web/package.json
@@ -13,7 +13,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "e2e": "playwright test",
+    "e2e:install": "playwright install --with-deps chromium webkit"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^1.10.0",
@@ -26,6 +28,8 @@
     "react-router-dom": "^7.1.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.1",
+    "@types/node": "^20.19.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend_web/playwright.config.ts
+++ b/frontend_web/playwright.config.ts
@@ -1,0 +1,64 @@
+// frontend_web/playwright.config.ts
+//
+// Phase 3c Slice 6 — live-browser smoke harness.
+// Motivated by Incident 09 (Phase 3): loopback / fixture-based tests
+// silently passed while every real-browser Opus frame failed to
+// decode. Playwright runs the actual host page in chromium + webkit
+// so UI-level regressions (missing <dialog> support, focus trap,
+// ADR-0024 consent-modal appearance) cannot hide behind unit tests.
+//
+// Browsers are kept repo-local per CLAUDE.md Rule 6 (hermetic
+// toolchains): set `PLAYWRIGHT_BROWSERS_PATH` to a repo-scoped
+// directory before running tests. The `frontend.sh e2e` wrapper
+// does that automatically.
+
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  // Single worker keeps the dev server logs readable during a
+  // failure and avoids port races on the shared 5173.
+  workers: 1,
+  fullyParallel: false,
+  // Fail the CI run if a test accidentally ships with .only().
+  forbidOnly: !!process.env["CI"],
+  retries: process.env["CI"] ? 1 : 0,
+  reporter: process.env["CI"] ? "github" : "list",
+  use: {
+    baseURL: "http://127.0.0.1:5173",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    // WebKit is the critical cross-WebView target per ADR-0002
+    // Constraint 4 (Safari / WKWebView behaviour). Chromium alone
+    // would let WKWebView-specific regressions hide.
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+  ],
+  // Spin up Vite in local deploy mode (dummy principal, no Cognito
+  // redirect) for the duration of the test run. Playwright waits
+  // on the URL before dispatching tests.
+  //
+  // We invoke Vite via `node node_modules/vite/bin/vite.js` rather
+  // than `pnpm exec vite` because Playwright's webServer runs in a
+  // plain `/bin/sh` subshell: the hermetic pnpm from the frontend.sh
+  // wrapper is reached via an absolute path, so `pnpm` itself is
+  // not on PATH. Node IS on PATH (the wrapper prepends it), which
+  // is enough to reach the locally-installed vite.
+  webServer: {
+    command:
+      "node node_modules/vite/bin/vite.js --host 127.0.0.1 --port 5173 --strictPort",
+    url: "http://127.0.0.1:5173",
+    timeout: 60_000,
+    reuseExistingServer: !process.env["CI"],
+    env: {
+      VITE_AEGIS_DEPLOY_MODE: "local",
+    },
+  },
+});

--- a/frontend_web/tsconfig.json
+++ b/frontend_web/tsconfig.json
@@ -21,8 +21,8 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "types": ["vite/client"]
+    "types": ["vite/client", "node"]
   },
-  "include": ["src"],
+  "include": ["src", "e2e", "playwright.config.ts"],
   "exclude": ["node_modules", "dist", "tests"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,12 @@ importers:
         specifier: ^7.1.0
         version: 7.1.0(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
+      "@playwright/test":
+        specifier: ^1.49.1
+        version: 1.49.1
+      "@types/node":
+        specifier: ^20.19.0
+        version: 20.19.0
       "@types/react":
         specifier: ^19.1.0
         version: 19.1.0
@@ -48,7 +54,7 @@ importers:
         version: 5.7.2
       vite:
         specifier: ^6.0.7
-        version: 6.0.7
+        version: 6.0.7(@types/node@20.19.0)
 
 packages:
   /@babel/code-frame@7.29.0:
@@ -660,6 +666,17 @@ packages:
       "@jridgewell/sourcemap-codec": 1.5.5
     dev: true
 
+  /@playwright/test@1.49.1:
+    resolution:
+      {
+        integrity: sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+    dependencies:
+      playwright: 1.49.1
+    dev: true
+
   /@rollup/rollup-android-arm-eabi@4.60.1:
     resolution:
       {
@@ -990,6 +1007,15 @@ packages:
       }
     dev: true
 
+  /@types/node@20.19.0:
+    resolution:
+      {
+        integrity: sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==,
+      }
+    dependencies:
+      undici-types: 6.21.0
+    dev: true
+
   /@types/react-dom@19.1.0(@types/react@19.1.0):
     resolution:
       {
@@ -1024,7 +1050,7 @@ packages:
       "@babel/plugin-transform-react-jsx-source": 7.27.1(@babel/core@7.29.0)
       "@types/babel__core": 7.20.5
       react-refresh: 0.14.2
-      vite: 6.0.7
+      vite: 6.0.7(@types/node@20.19.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1148,6 +1174,17 @@ packages:
     engines: { node: ">=6" }
     dev: true
 
+  /fsevents@2.3.2:
+    resolution:
+      {
+        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /fsevents@2.3.3:
     resolution:
       {
@@ -1247,6 +1284,28 @@ packages:
       {
         integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
       }
+    dev: true
+
+  /playwright-core@1.49.1:
+    resolution:
+      {
+        integrity: sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+    dev: true
+
+  /playwright@1.49.1:
+    resolution:
+      {
+        integrity: sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+    dependencies:
+      playwright-core: 1.49.1
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /postcss@8.5.9:
@@ -1420,6 +1479,13 @@ packages:
     hasBin: true
     dev: true
 
+  /undici-types@6.21.0:
+    resolution:
+      {
+        integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
+      }
+    dev: true
+
   /update-browserslist-db@1.2.3(browserslist@4.28.2):
     resolution:
       {
@@ -1434,7 +1500,7 @@ packages:
       picocolors: 1.1.1
     dev: true
 
-  /vite@6.0.7:
+  /vite@6.0.7(@types/node@20.19.0):
     resolution:
       {
         integrity: sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==,
@@ -1477,6 +1543,7 @@ packages:
       yaml:
         optional: true
     dependencies:
+      "@types/node": 20.19.0
       esbuild: 0.24.2
       postcss: 8.5.9
       rollup: 4.60.1

--- a/tools/scripts/frontend.sh
+++ b/tools/scripts/frontend.sh
@@ -87,6 +87,12 @@ export PATH="$NODE_BIN_DIR:$PATH"
 # exits immediately with FATAL: BAZEL_BINDIR must be set.
 export BAZEL_BINDIR="."
 
+# Playwright browsers must be repo-local per CLAUDE.md Rule 6
+# (hermetic toolchains — nothing touches ~/.cache or system dirs).
+# Every `e2e` / `e2e:install` invocation therefore points Playwright
+# at a .playwright-browsers/ directory inside the repo, gitignored.
+export PLAYWRIGHT_BROWSERS_PATH="$REPO_ROOT/.playwright-browsers"
+
 cmd="${1:-help}"
 shift || true
 
@@ -96,7 +102,7 @@ case "$cmd" in
     # (currently just frontend_web/) get their deps.
     exec "$PNPM_BIN" --dir "$REPO_ROOT" install "$@"
     ;;
-  dev|build|typecheck|preview)
+  dev|build|typecheck|preview|e2e|e2e:install)
     # Every other "named" command delegates to pnpm scripts inside
     # frontend_web's package.json.
     exec "$PNPM_BIN" --dir "$REPO_ROOT/frontend_web" run "$cmd" "$@"
@@ -111,6 +117,11 @@ Commands:
   build                   Production build → frontend_web/dist/.
   typecheck               Run tsc --noEmit across the frontend tree.
   preview                 Preview the production build locally.
+  e2e                     Run Playwright live-browser smoke tests
+                          (chromium + webkit). Spawns its own dev
+                          server per playwright.config.ts#webServer.
+  e2e:install             One-time browser binary download into
+                          ./.playwright-browsers/ (repo-local).
   <anything else>         Passed through to pnpm with --dir frontend_web.
 
 Every invocation uses the Bazel-managed Node toolchain; host Node

--- a/tools/scripts/frontend.sh
+++ b/tools/scripts/frontend.sh
@@ -30,18 +30,35 @@ cd "$REPO_ROOT"
 resolve_node_bin_dir() {
   local output_base
   output_base="$("$REPO_ROOT/tools/bazelisk/bazelisk" info output_base 2>/dev/null)"
-  # Typical layouts under rules_nodejs + aspect_rules_js toolchain:
+  # Probe known layouts first — fast path, no recursive scan.
   for candidate in \
     "$output_base/external/rules_nodejs~~node~nodejs_darwin_arm64/bin" \
     "$output_base/external/rules_nodejs~~node~nodejs_darwin_amd64/bin" \
     "$output_base/external/rules_nodejs~~node~nodejs_linux_amd64/bin" \
-    "$output_base/external/rules_nodejs~~node~nodejs_linux_arm64/bin"
+    "$output_base/external/rules_nodejs~~node~nodejs_linux_arm64/bin" \
+    "$output_base/external/rules_nodejs~node~nodejs_darwin_arm64/bin" \
+    "$output_base/external/rules_nodejs~node~nodejs_darwin_amd64/bin" \
+    "$output_base/external/rules_nodejs~node~nodejs_linux_amd64/bin" \
+    "$output_base/external/rules_nodejs~node~nodejs_linux_arm64/bin"
   do
     if [[ -x "$candidate/node" ]]; then
       echo "$candidate"
       return 0
     fi
   done
+  # Fallback: scan external/ for any nodejs_* repo that actually
+  # contains an executable `node`. Slower but insulates the wrapper
+  # from repo-mapping naming changes across rules_nodejs versions
+  # (single- vs double-tilde, prefix changes, etc.). Depth 2 keeps
+  # the scan bounded — the target dir is external/<repo>/bin.
+  local found
+  found="$(find "$output_base/external" -maxdepth 3 -type f -name node -perm -u+x 2>/dev/null \
+           | grep -E '/nodejs_(linux|darwin|windows)_[a-z0-9_]+/bin/node$' \
+           | head -n 1)"
+  if [[ -n "$found" ]]; then
+    dirname "$found"
+    return 0
+  fi
   return 1
 }
 

--- a/tools/scripts/frontend.sh
+++ b/tools/scripts/frontend.sh
@@ -62,10 +62,19 @@ resolve_node_bin_dir() {
   return 1
 }
 
-# Ensure the Node toolchain is downloaded. First-run cost is ~30s
-# on a cold Bazel cache; subsequent runs are cache hits.
-"$REPO_ROOT/tools/bazelisk/bazelisk" build \
-  @rules_nodejs//nodejs:resolved_toolchain >/dev/null 2>&1 || true
+# Ensure the hermetic pnpm binary is materialised. Building @pnpm
+# transitively fetches the @rules_nodejs Node toolchain because the
+# pnpm js_binary target depends on it, so a single `bazelisk build`
+# populates everything `resolve_node_bin_dir` looks for. We surface
+# the output on failure so a toolchain-fetch problem in CI shows up
+# as a clear Bazel error instead of cascading into the "node binary
+# not found" message from the resolver. First-run cost is ~30s on a
+# cold Bazel cache; subsequent runs are cache hits.
+if ! "$REPO_ROOT/tools/bazelisk/bazelisk" build @pnpm//:pnpm >/dev/null 2>&1; then
+  echo "error: failed to build @pnpm//:pnpm — re-running with visible output:" >&2
+  "$REPO_ROOT/tools/bazelisk/bazelisk" build @pnpm//:pnpm >&2
+  exit 1
+fi
 
 NODE_BIN_DIR="$(resolve_node_bin_dir || true)"
 if [[ -z "${NODE_BIN_DIR:-}" ]]; then
@@ -86,9 +95,32 @@ EOF
   exit 1
 fi
 
-# Bazel-managed pnpm — built once, then available as a plain binary.
-"$REPO_ROOT/tools/bazelisk/bazelisk" build @pnpm//:pnpm >/dev/null 2>&1
-PNPM_BIN="$REPO_ROOT/bazel-bin/external/aspect_rules_js~~pnpm~pnpm/pnpm_/pnpm"
+# Bazel-managed pnpm — already built by the step above. Resolve its
+# concrete path; the repo-mapping layout can use single or double
+# tildes depending on rules version, so probe both.
+resolve_pnpm_bin() {
+  for candidate in \
+    "$REPO_ROOT/bazel-bin/external/aspect_rules_js~~pnpm~pnpm/pnpm_/pnpm" \
+    "$REPO_ROOT/bazel-bin/external/aspect_rules_js~pnpm~pnpm/pnpm_/pnpm"; do
+    if [[ -x "$candidate" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  # Fallback: glob for any pnpm wrapper Bazel has materialised.
+  local found
+  found="$(find "$REPO_ROOT/bazel-bin/external" -maxdepth 4 -type f -name pnpm -perm -u+x 2>/dev/null | grep -E '/pnpm_/pnpm$' | head -n 1)"
+  if [[ -n "$found" ]]; then
+    echo "$found"
+    return 0
+  fi
+  return 1
+}
+PNPM_BIN="$(resolve_pnpm_bin || true)"
+if [[ -z "${PNPM_BIN:-}" ]]; then
+  echo "error: built @pnpm//:pnpm but could not locate the pnpm binary under bazel-bin/external/." >&2
+  exit 1
+fi
 
 # Prepend Node to PATH for the subprocess only. The pnpm binary we
 # invoke below will shell out to `node` internally (it's a Node


### PR DESCRIPTION
## Summary

Incident 09 lesson in code: loopback / fixture-based tests silently passed while every real-browser Opus frame failed to decode. A smoke test that actually renders the host page in **chromium + webkit** — not a jsdom approximation — would have caught the gap on the first run. This slice wires the harness.

## Highlights

- `@playwright/test` + `@types/node` as devDependencies, hermetic pnpm lockfile (ADR-0015).
- `playwright.config.ts` drives chromium + webkit projects. WebServer invokes Vite via `node node_modules/vite/bin/vite.js` (Node is on PATH via `frontend.sh`, pnpm is not).
- `frontend_web/e2e/consent-smoke.spec.ts` — ADR-0024 A + B acceptance:
  - Audio modal appears on first visit; Agree dismisses; no decline/cancel (closable=false contract).
  - Acceptance persists across reloads.
  - Transcript checkbox defaults OFF; GDPR Art. 6(1)(f) notice only after opt-in.
- `tools/scripts/frontend.sh` adds `e2e` / `e2e:install`; pins `PLAYWRIGHT_BROWSERS_PATH=./.playwright-browsers` (CLAUDE.md Rule 6).
- `.gitignore` keeps browsers + reports out of git.
- CI: new `frontend-e2e-smoke` job with browser cache keyed on `pnpm-lock.yaml`; uploads report artifact on failure. **8 jobs now in matrix.**

## Local validation

6 tests pass (3 chromium + 3 webkit) in ~4s after browsers are downloaded once.

## Test plan

- [x] `./tools/scripts/frontend.sh typecheck` green
- [x] `./tools/scripts/frontend.sh build` green (184 modules)
- [x] `./tools/scripts/check_frontend_tauri_compliance.sh` green
- [x] `./tools/scripts/frontend.sh e2e` green (6/6 chromium + webkit)
- [ ] CI 8-job matrix green (new frontend-e2e-smoke must pass)
- [ ] Admin merge after CI green