### PR TITLE
chore(governance): pre-Phase-4 cleanup — PR template + gh_bootstrap + TODO sweep

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+<!--
+  Aegis Core PR template.
+  Match the shape: Summary → Files → Test plan. Conventional Commits
+  scope goes in the PR title (e.g. `feat(host): …`, `fix(gateway): …`,
+  `docs(adr): …`); commit message scopes are enforced by the
+  `--force-scope` pre-commit hook, so the title should line up.
+  Delete any section that doesn't apply rather than leaving it blank.
+-->
+
+## Summary
+
+<!--
+  1-3 sentences on the *why* — what problem this PR solves or what
+  capability it unlocks. Not "what it does" (the diff shows that).
+  Link ADRs, ARCH §s, ROADMAP items, issues.
+-->
+
+## Files
+
+<!--
+  Optional but load-bearing for multi-file PRs. Call out new files
+  and non-obvious edits. Skip if the diff is small and self-explanatory.
+-->
+
+## Test plan
+
+<!--
+  Checkbox list. Lean on the 8-job CI matrix; add manual verification
+  steps only where CI cannot prove the thing.
+-->
+
+- [ ] `./tools/bazelisk/bazelisk test //…` (or scoped targets) green
+- [ ] `./tools/scripts/frontend.sh typecheck && build` green (if frontend touched)
+- [ ] `./tools/scripts/check_frontend_tauri_compliance.sh` green (if frontend touched)
+- [ ] `./tools/scripts/frontend.sh e2e` green (if host UI touched)
+- [ ] 8-job CI matrix green before admin-merge
+
+## Notes
+
+<!--
+  Anything a reviewer should know that isn't obvious from the diff:
+  rollback plan for risky change, follow-up issue filed, deferred
+  work, incident postmortem linked, etc.
+-->

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -421,8 +421,10 @@ gh api --method PUT repos/BinHsu/aegis-core/automated-security-fixes
 - ✅ Dependency graph (usually on by default for public repos)
 - ✅ Dependabot alerts → Enable
 - ✅ Dependabot security updates → Enable
-- ⬜ Dependabot version updates — configured via
-  `.github/dependabot.yml` (TODO Phase 1 when dependencies exist)
+- ✅ Dependabot version updates — configured via
+  [`.github/dependabot.yml`](../.github/dependabot.yml) (five
+  ecosystems: github-actions, gomod, npm, bazel, plus a commented-out
+  Docker stanza waiting for Phase 4a)
 
 ### Verify
 
@@ -516,9 +518,15 @@ support category creation).
 
 ## 8. Issue Templates and PR Template
 
-File-based, not UI. Create `.github/ISSUE_TEMPLATE/*.yml` and
-`.github/PULL_REQUEST_TEMPLATE.md`. TODO Phase 0+ — not blocking
-Phase 0 completion.
+File-based, not UI.
+
+- ✅ PR template — [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md)
+  — matches the Summary / Files / Test plan shape the session PRs
+  already use, with the 8-job CI matrix called out as the default
+  gate.
+- ⬜ Issue templates — `.github/ISSUE_TEMPLATE/*.yml`. Deferred until
+  external contributors start opening issues; the current single-
+  maintainer flow doesn't benefit from them.
 
 ---
 
@@ -527,11 +535,15 @@ Phase 0 completion.
 For fresh repo setup, the Phase 0 maintainer can run:
 
 ```bash
-./tools/scripts/gh_bootstrap.sh BinHsu/aegis-core
+./tools/scripts/gh_bootstrap.sh                 # defaults to BinHsu/aegis-core
+./tools/scripts/gh_bootstrap.sh owner/repo      # for a fork
 ```
 
-(Script TODO Phase 0+ — lives at `tools/scripts/gh_bootstrap.sh`
-when created. Until then, run the `gh` commands above in order.)
+The script asserts §§2, 3, 4, 6, and 7 idempotently. It deliberately
+does NOT apply §0 (destructive visibility toggle), §0.5 (interactive
+`ssh-keygen`), §1 (long ruleset JSON — apply by hand), §5 (CodeQL —
+Phase 4b scope per ROADMAP), or §7 category creation (REST API does
+not support it).
 
 ---
 

--- a/tools/scripts/gh_bootstrap.sh
+++ b/tools/scripts/gh_bootstrap.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# tools/scripts/gh_bootstrap.sh
+#
+# One-shot GitHub-side bootstrap for a fresh Aegis Core clone. Applies
+# the configurations that §§2–7 of docs/github-setup.md describe, in
+# the order the doc prescribes. Idempotent: every operation re-asserts
+# the desired state rather than creating-if-missing, so re-running is
+# safe after a partial run.
+#
+# NOT applied here (the doc calls them out as manual / interactive):
+# - §0   repository visibility toggle (destructive, confirmation prompt)
+# - §0.5 SSH commit signing key generation (interactive `ssh-keygen`)
+# - §1   branch-protection ruleset (depends on §0.5 being done first; full
+#         JSON body is in docs/github-setup.md, too long to inline here)
+# - §5   CodeQL default setup (Phase 4b scope per ROADMAP.md:314)
+# - §7   Discussions category creation (REST API can't create categories)
+#
+# Usage:
+#   ./tools/scripts/gh_bootstrap.sh                    # defaults to BinHsu/aegis-core
+#   ./tools/scripts/gh_bootstrap.sh owner/repo         # apply to a fork
+#
+# Requires: `gh` CLI authenticated with admin scope on the target repo.
+# Check via:  gh auth status
+
+set -euo pipefail
+
+REPO="${1:-BinHsu/aegis-core}"
+
+info() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+ok()   { printf '    \033[0;32m✓\033[0m %s\n' "$*"; }
+warn() { printf '    \033[0;33m⚠\033[0m %s\n' "$*" >&2; }
+
+# --- Sanity: gh auth + repo reachability --------------------------------
+info "Verifying gh auth + repo access ($REPO)"
+gh auth status >/dev/null
+gh repo view "$REPO" >/dev/null
+ok "gh auth OK + $REPO reachable"
+
+# --- §2 Private vulnerability reporting ---------------------------------
+info "§2 Private vulnerability reporting"
+gh api --method PUT "repos/$REPO/private-vulnerability-reporting" >/dev/null
+ok "private-vulnerability-reporting enabled"
+
+# --- §3 Secret scanning + push protection -------------------------------
+# Public repos only — the API returns 403 on private repos without
+# GitHub Advanced Security. The doc notes this; we tolerate the 403.
+info "§3 Secret scanning + push protection"
+if gh api --method PATCH "repos/$REPO" \
+    -F "security_and_analysis[secret_scanning][status]=enabled" \
+    -F "security_and_analysis[secret_scanning_push_protection][status]=enabled" \
+    >/dev/null 2>&1; then
+  ok "secret scanning + push protection enabled"
+else
+  warn "secret scanning PATCH refused — likely a private repo without GHAS. Enable via Settings → Code security and analysis."
+fi
+
+# --- §4 Dependabot alerts + security updates ----------------------------
+# Version-updates config lives in .github/dependabot.yml (already
+# committed); these two endpoints flip on the repo-level features.
+info "§4 Dependabot alerts + security updates"
+gh api --method PUT "repos/$REPO/vulnerability-alerts" >/dev/null
+ok "vulnerability-alerts enabled"
+gh api --method PUT "repos/$REPO/automated-security-fixes" >/dev/null
+ok "automated-security-fixes enabled"
+
+# --- §6 Actions permissions --------------------------------------------
+info "§6 Actions permissions (selected, verified + GitHub-owned)"
+gh api --method PUT "repos/$REPO/actions/permissions" \
+  -F enabled=true \
+  -f "allowed_actions=selected" >/dev/null
+gh api --method PUT "repos/$REPO/actions/permissions/selected-actions" \
+  -F "github_owned_allowed=true" \
+  -F "verified_allowed=true" >/dev/null
+ok "Actions limited to GitHub-owned + verified"
+
+gh api --method PUT "repos/$REPO/actions/permissions/access" \
+  -f "access_level=none" >/dev/null
+ok "outside-collaborator fork-PR workflows require approval"
+
+gh api --method PUT "repos/$REPO/actions/permissions/workflow" \
+  -F "default_workflow_permissions=read" \
+  -F "can_approve_pull_request_reviews=false" >/dev/null
+ok "default GITHUB_TOKEN scope = read-only; cannot approve PRs"
+
+# --- §7 Discussions -----------------------------------------------------
+info "§7 Discussions feature"
+gh api --method PATCH "repos/$REPO" \
+  -F "has_discussions=true" >/dev/null
+ok "Discussions feature enabled (create categories via UI)"
+
+# --- Summary ------------------------------------------------------------
+cat <<EOF
+
+\033[1;32mBootstrap complete for $REPO.\033[0m
+
+Manual follow-ups from docs/github-setup.md still required:
+  - §0.5 SSH commit signing key (interactive; one-time per machine)
+  - §1   Branch-protection ruleset (JSON body in the doc; gh api PUT)
+  - §7   Discussion categories (UI only — REST cannot create them)
+  - §5   CodeQL default setup (Phase 4b scope; enable when scanning lands)
+
+Verify:
+  gh api repos/$REPO/actions/permissions
+  gh api repos/$REPO/vulnerability-alerts          # HTTP 204 = on
+  gh api repos/$REPO --jq '.security_and_analysis'
+EOF


### PR DESCRIPTION
## Summary

Clear three Phase 0/1 house-keeping TODOs that `docs/github-setup.md` has been carrying, so the governance posture is clean before Phase 4 work starts. `dependabot.yml` was already substantive; only the doc line-425 TODO marker needed clearing.

## Files

- `.github/PULL_REQUEST_TEMPLATE.md` (new) — matches session PR shape (Summary / Files / Test plan + 8-job CI matrix).
- `tools/scripts/gh_bootstrap.sh` (new) — idempotent one-shot for §§2/3/4/6/7; skips destructive + interactive + Phase-4b-scope sections.
- `docs/github-setup.md` — three TODO markers cleared (§4 dependabot, §8 PR template, §"One-shot bootstrap script").

## Test plan

- [x] `shellcheck tools/scripts/gh_bootstrap.sh` clean (pre-commit hook)
- [ ] 8-job CI matrix green
- [ ] Admin merge after CI green