### PR TITLE
feat(packaging): Phase 4a Slice 1 — rules_oci + Go Gateway distroless image (local-only)

### DIFF
--- a/.github/workflows/ci-baseline.yml
+++ b/.github/workflows/ci-baseline.yml
@@ -183,13 +183,63 @@ jobs:
           EOF
           echo "BuildBuddy cache configured. Invocation dashboard: https://app.buildbuddy.io/"
 
-      - name: Build proto + engine + gateway
+      - name: Build proto + engine + gateway + gateway OCI image
         run: |
+          # //packaging/gateway:image is the Phase 4a Slice 1 OCI smoke
+          # target — builds the distroless layered image. ADR-0025.
           ./tools/bazelisk/bazelisk build \
             //proto/aegis/v1:aegis_cc_grpc \
             //proto/aegis/v1:aegis_go_proto \
             //engine_cpp/cmd/engine:engine \
-            //gateway_go/cmd/gateway:gateway
+            //gateway_go/cmd/gateway:gateway \
+            //packaging/gateway:image
+
+      # ADR-0025 Camp B / dev-CI split: dev boxes never need Docker
+      # (host-native binary suffices for development). CI is the SOLE
+      # gate that proves "image actually boots inside a container", and
+      # is the leftmost gate in the promotion chain to staging
+      # (Trivy / Cosign / ECR push / ArgoCD sync land downstream in
+      # Slices 4a-3 and Phase 4b). Skipping this would make Camp B
+      # untenable.
+      #
+      # Verifies, in order:
+      #   1. image loads into runner Docker (validates rules_oci output)
+      #   2. container starts as nonroot under read-only rootfs
+      #      (validates ADR-0025 runtime posture, not just BUILD claims)
+      #   3. /healthz returns 200 within 10s (validates the static-linked
+      #      gateway binary actually executes inside distroless — catches
+      #      missing /etc/passwd, DNS, certs, etc.)
+      #   4. container is removed cleanly (no leak into next CI run)
+      - name: Smoke-test gateway OCI image (boot + healthz + read-only rootfs)
+        run: |
+          set -euxo pipefail
+          ./tools/bazelisk/bazelisk run //packaging/gateway:image_load -- aegis-gateway:ci-smoke
+          docker run -d --name gw \
+            --read-only \
+            --user 65532:65532 \
+            -p 18080:8080 \
+            aegis-gateway:ci-smoke
+          # Wait up to 10s for /healthz to return 200; the gateway tries
+          # to dial the C++ engine on startup, which fails (engine isn't
+          # in this CI step), but per main.go:440-443 /healthz still
+          # returns 200 with engine.reachable=false. That's the expected
+          # boot-up shape and what we're validating here.
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -sf http://localhost:18080/healthz > /tmp/healthz.json; then
+              echo "healthz returned 200 after ${i}s"
+              cat /tmp/healthz.json
+              break
+            fi
+            sleep 1
+            if [ "$i" = "10" ]; then
+              echo "ERROR: healthz never returned 200 within 10s"
+              docker logs gw
+              exit 1
+            fi
+          done
+          docker logs gw
+          docker stop gw
+          docker rm gw
 
       # ADR-0021 P3 — shared ggml runtime drift check.
       #

--- a/.github/workflows/ci-baseline.yml
+++ b/.github/workflows/ci-baseline.yml
@@ -213,12 +213,17 @@ jobs:
       - name: Smoke-test gateway OCI image (boot + healthz + read-only rootfs)
         run: |
           set -euxo pipefail
-          ./tools/bazelisk/bazelisk run //packaging/gateway:image_load -- aegis-gateway:ci-smoke
+          # The image_load target's repo_tags are defined in
+          # packaging/gateway/BUILD.bazel as "aegis-gateway:dev-local";
+          # `bazel run` does NOT accept a tag override as a positional
+          # argument (oci_load reads repo_tags from the BUILD attribute,
+          # not from argv). Aligning the docker tag below.
+          ./tools/bazelisk/bazelisk run //packaging/gateway:image_load
           docker run -d --name gw \
             --read-only \
             --user 65532:65532 \
             -p 18080:8080 \
-            aegis-gateway:ci-smoke
+            aegis-gateway:dev-local
           # Wait up to 10s for /healthz to return 200; the gateway tries
           # to dial the C++ engine on startup, which fails (engine isn't
           # in this CI step), but per main.go:440-443 /healthz still

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -303,6 +303,10 @@ Bazel hermeticity gives Aegis a strong **build reproducibility** foundation, but
 - **Model provenance**: every `.gguf` / `.bin` model file in `/models` has a corresponding `manifest.json` entry with SHA256, origin URL, license, and a PGP-signed attestation. The model loader refuses to `mmap` a file whose hash does not match its manifest entry. See `/models/README.md`.
 - **License scanning**: a license scanner (ScanCode, FOSSA, or equivalent) runs on every PR. Merges to `main` are blocked if any new dependency introduces a license incompatible with the project's stated license terms (GPL/AGPL in particular).
 
+##### 10.1.1 OCI image construction
+
+Container images are built via **`rules_oci` v2** as Bazel actions — no `Dockerfile` and no Docker daemon participate in the build. Base images are **distroless** (`gcr.io/distroless/static-debian12:nonroot` for fully-static Go binaries; `base-debian12` / `cc-debian12` variants reserved for the C++ engine when Slice 4 lands), pinned by **SHA256 manifest-list digest** rather than by tag. Each image runs as **uid/gid 65532 (`nonroot`)**, ships no shell or package manager, and is read-only-rootfs-compatible. Multi-arch (`linux/amd64` + `linux/arm64/v8`) is enabled at the `oci.pull` extension level so EKS Graviton nodepools consume the same image index. Full rationale: ADR-0025; first wiring is in `packaging/gateway/BUILD.bazel`.
+
 #### 10.2 Static Analysis (SAST)
 
 | Language | Tools |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -217,12 +217,56 @@ npm.npm_translate_lock(
 use_repo(npm, "npm")
 
 # -----------------------------------------------------------------------------
+# OCI packaging — Phase 4a. ADR-0025 documents the strategy
+# (rules_oci over Dockerfile/ko/Buildah, distroless static-debian12:nonroot
+# over scratch/Alpine/Wolfi, digest pinning, non-root + read-only rootfs).
+#
+# rules_pkg supplies pkg_tar, used to layer Bazel-built binaries into the
+# image. rules_oci pulls the base, composes layers, and produces the OCI
+# image directory (oci_load adds local `docker load` for smoke testing —
+# CI does NOT need oci_load, just builds the oci_image target).
+# -----------------------------------------------------------------------------
+bazel_dep(name = "rules_oci", version = "2.0.1")
+bazel_dep(name = "rules_pkg", version = "1.0.1")
+
+oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
+
+# Distroless static-debian12:nonroot — pinned by SHA256 manifest-list
+# digest (NOT the tag). Digest captured 2026-04-19 via:
+#   curl -sI https://gcr.io/v2/distroless/static-debian12/manifests/nonroot \
+#     -H "Accept: application/vnd.oci.image.index.v1+json"
+# Re-pin when bumping; record provenance in the commit message.
+#
+# Why static-debian12 + nonroot variant:
+#   - Pure-Go binaries linked with pure=on/static=on need only a static base.
+#   - The :nonroot variant ships a uid/gid 65532 user so we don't have to
+#     synthesize one ourselves; combined with oci_image `user = "nonroot"`
+#     it satisfies the "non-root + dropped caps" line in ROADMAP §Phase 4a.
+#
+# Multi-arch: pull both linux/amd64 and linux/arm64/v8 so future EKS
+# nodepools (Graviton-friendly) can consume the same image index.
+oci.pull(
+    name = "distroless_static",
+    digest = "sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1",
+    image = "gcr.io/distroless/static-debian12",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64/v8",
+    ],
+)
+use_repo(
+    oci,
+    "distroless_static",
+    "distroless_static_linux_amd64",
+    "distroless_static_linux_arm64_v8",
+)
+
+# -----------------------------------------------------------------------------
 # Phase 4+ dependencies (added as each component comes online):
 #
-#   bazel_dep(name = "rules_oci",        version = "2.0.1")    # Phase 4 packaging
 #   bazel_dep(name = "rules_rust",       version = "0.54.0")   # Phase 4 Tauri
 #
-# They are commented here, not added, because:
+# Commented here, not added, because:
 #   (a) Each dep adds build graph surface and possible version conflicts.
 #   (b) We unblock one language at a time with a verified checkpoint.
 # -----------------------------------------------------------------------------

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,9 @@ the privacy posture defined in `ARCHITECTURE.md` §9.
 - [x] Add `rules_cc`, `grpc`, `apple_support` bazel_deps — Session 2 (cold grpc build 5m14s)
 - [x] Add `rules_foreign_cc` 0.15.1 + whisper.cpp v1.8.4 via http_archive+SHA256, CMake build — Session 4a (cold +7m38s)
 - [x] Add `rules_go` 0.52.0 + `gazelle` 0.50.0 bazel_deps + Go 1.24.12 hermetic SDK — Session 5
-- [ ] Add `rules_nodejs`, `rules_rust`, `rules_oci` bazel_deps — Phase 3/4
+- [x] Add `rules_nodejs` (via `aspect_rules_js`) bazel_dep — Phase 3 (ADR-0015)
+- [x] Add `rules_oci` + `rules_pkg` bazel_deps — Phase 4a Slice 1 (ADR-0025)
+- [ ] Add `rules_rust` bazel_dep — Phase 4 Tauri
 - [x] Configure `.bazelrc` with CPU default, metal/cuda/cpu configs, `try-import %workspace%/.bazelrc.user` (ADR-0009)
 - [x] `.bazelversion` pinning Bazel 7.4.1
 - [x] Add `tools/bazelisk/bazelisk` wrapper — downloads bazelisk locally, forces `--output_user_root=./.bazel_cache` (CLAUDE.md Rule 6)
@@ -300,10 +302,16 @@ Gated by 3b — prompter display needs real transcript data; corpus selector nee
 > *"Make it deployable. Sign it. Roll it out safely."*
 
 ### Phase 4a: Package
-- [ ] Bazel `rules_oci`: package C++ engine, Go GW, and frontend into Distroless OCI images
-- [ ] Each image runs as non-root with dropped capabilities and read-only root filesystem except tmpfs mounts
-- [ ] Image tagging convention: `prod-<semver>-<git_sha>`, `staging-<git_sha>`, `dev-<git_sha>`
-- [ ] Produce SBOMs (Syft / CycloneDX) alongside every image (ARCH §10.1)
+- [~] Bazel `rules_oci`: package C++ engine, Go GW, and frontend into Distroless OCI images
+  - [x] Slice 1 — `rules_oci` + `rules_pkg` wired; Go gateway `aegis-gateway` image local-buildable, distroless `static-debian12:nonroot` base pinned by digest (ADR-0025)
+  - [ ] Slice 2 — SBOM generation (Syft / CycloneDX) per image
+  - [ ] Slice 3 — GitHub Actions ECR push via `github-actions-aegis-core-ecr` OIDC role (ldz #74; gated on ldz `terraform-apply-baseline.yml` per ldz #75)
+  - [ ] Slice 4 — C++ engine `aegis-engine` image (distroless `base-debian12` or `cc-debian12`, hermetic clang × dynamic-lib story)
+  - [ ] Slice 5 — Frontend `aegis-frontend` image (static asset packaging)
+- [~] Each image runs as non-root with dropped capabilities and read-only root filesystem except tmpfs mounts
+  - [x] Gateway image: `user = "nonroot"` (uid 65532), entrypoint is binary path (no shell), distroless ships no package manager (Slice 1)
+- [ ] Image tagging convention: `prod-<semver>-<git_sha>`, `staging-<git_sha>`, `dev-<git_sha>` — wired in Slice 3 alongside ECR push
+- [ ] Produce SBOMs (Syft / CycloneDX) alongside every image (ARCH §10.1) — Slice 2
 
 ### Phase 4b: Sign & Scan
 - [ ] Cosign / Sigstore signing in GitHub Actions using OIDC (ARCH §10.1)
@@ -322,6 +330,8 @@ Gated by 3b — prompter display needs real transcript data; corpus selector nee
 - [ ] Graceful shutdown verified end-to-end under rolling update (ADR-0006)
 - [ ] Audio-namespace Kyverno / Gatekeeper policies (ADR-0005 R6): reject PVC, reject hostPath
 - [ ] Velero backup schedule explicitly excludes `aegis-audio` namespace (ADR-0005 R6)
+- [ ] **Post-deploy E2E suite against staging** — Playwright / API-level happy-path drive (CreateMeeting → audio → transcript → JoinAsViewer → EndMeeting) executed against the deployed staging URL after every ArgoCD sync. Today (Phase 4a) the only post-deploy verification is the kubelet `/healthz` probe (extremely narrow) and a human walking through the UI. Closing this gap converts "human notices the demo broke" into "machine blocks the next promotion."
+- [ ] **Synthetic monitoring against staging + prod** — external probe (CloudWatch Synthetics, Better Uptime, or equivalent) hits public endpoints every N minutes and pages oncall on SLO-burn. Pairs with the canary gate above so a regression that escapes canary still gets caught within minutes.
 
 ### Phase 4d: Observability Wiring + Build Cache Decision
 

--- a/docs/adr/0025-oci-packaging-strategy.md
+++ b/docs/adr/0025-oci-packaging-strategy.md
@@ -1,0 +1,291 @@
+# ADR-0025: OCI image packaging via `rules_oci` + distroless static base
+
+| Field    | Value                                                                       |
+| -------- | --------------------------------------------------------------------------- |
+| Status   | Accepted                                                                    |
+| Date     | 2026-04-19                                                                  |
+| Deciders | Project author                                                              |
+| Context  | Phase 4a — package the C++ engine, Go gateway, and frontend bundle into reproducible, signed-ready container images for EKS deployment. |
+| Related  | ADR-0014 (Bazel build cache strategy), ADR-0015 (hermetic Node.js), CLAUDE.md Rule 6 (hermetic toolchains), `ARCHITECTURE.md` §10.1 (Supply Chain Integrity), ROADMAP §Phase 4a/4b |
+
+## Context
+
+Phase 3c closed with three buildable binaries (C++ `engine`, Go
+`gateway`, frontend `dist/` bundle) all reachable through the hermetic
+Bazel graph. Phase 4a's task is to package each of these into an OCI
+image suitable for ECR push and EKS deployment, satisfying the
+following non-negotiables drawn from `ARCHITECTURE.md` §10 and
+`CLAUDE.md` Rule 6:
+
+1. **Hermetic build.** The image-build action must not depend on a
+   Docker daemon, host `docker build`, or any tool installed outside
+   the Bazel graph. The "clone, build, it just works" promise extends
+   to packaging.
+2. **Reproducible.** Two builds of the same Git SHA must produce
+   bit-identical image manifests (or at minimum: identical layer
+   digests for all non-timestamped layers).
+3. **Signable.** The output must be a standard OCI artifact that
+   Cosign / Sigstore (Phase 4b) can sign without translation.
+4. **Pinned base by digest, never tag.** Floating tags violate the
+   dependency-pinning principle in `ARCHITECTURE.md` §10.1.
+5. **Non-root, minimal attack surface.** Each image runs as a
+   non-root user and ships only what the binary needs at runtime — no
+   shell, no package manager, no debugging tools.
+
+The decision space cleaved across two axes:
+
+- **How** to produce the image: `Dockerfile` + `docker build`, `ko`
+  (Go-specific), `Buildah`, `kaniko`, or `rules_oci`.
+- **What** base image to use: `scratch`, distroless (Google), Alpine
+  Linux, Wolfi (Chainguard), Ubuntu/Debian-slim.
+
+## Decision
+
+### Build tool — `rules_oci` v2 (bazel-contrib)
+
+`rules_oci` is the Bazel-native rule set that constructs OCI images
+purely from Bazel actions, with no Docker daemon dependency. It pulls
+base images via the OCI distribution spec, layers Bazel-built artifacts
+on top via `pkg_tar`, and emits standard OCI image directories that
+Cosign / SBOM tooling consume directly.
+
+### Base image — `gcr.io/distroless/static-debian12:nonroot`
+
+Pinned by SHA256 manifest-list digest (multi-arch: linux/amd64 +
+linux/arm64/v8). The `:nonroot` variant ships a uid/gid 65532 user so
+no Dockerfile-equivalent `useradd` action is required.
+
+### Image layout convention
+
+- Binaries land at `/usr/local/bin/<binary-name>`.
+- Entrypoint is the binary path, not a shell wrapper (no shell exists).
+- Image runs as `user = "nonroot"`; rootfs is read-only-compatible
+  (no writes outside `/tmp` if a tmpfs is mounted at runtime).
+- OCI annotations include `org.opencontainers.image.source`, `.title`,
+  `.description`, `.licenses`. Tag-level provenance (git SHA, semver
+  per ROADMAP `:305` convention) attaches at push time (Slice 3).
+
+### Sequencing across slices
+
+| Slice | Scope | Image set |
+| --- | --- | --- |
+| 4a-1 (this ADR) | `rules_oci` wiring + Go gateway image; local-only, no push | `aegis-gateway` |
+| 4a-2 | SBOM via Syft (CycloneDX) attached to each image | (no new image) |
+| 4a-3 | GitHub Actions ECR push via OIDC role from ldz #74 | (no new image) |
+| 4a-4 | C++ engine image — exercises hermetic clang × distroless | `aegis-engine` |
+| 4a-5 | Frontend image — static asset packaging | `aegis-frontend` |
+| 4b   | Cosign signing + SLSA L3 + Trivy scan | (gates the above) |
+
+## Dev experience vs CI validation — Camp B / dev-CI split
+
+The Docker-era industry split into two camps on the question of
+"should developers run containers locally":
+
+- **Camp A (dev/prod parity):** developers `docker compose up` to
+  bring up the stack. Heroku-influenced, popular at typical SaaS
+  scale-ups. Catches container-only bugs early; slows dev iteration;
+  forces every contributor to install Docker.
+- **Camp B (Bazel-native):** developers `bazel run` binaries
+  directly. Container images are deployment artifacts validated by
+  CI, not dev tools. Used at Google, Meta, and most Bazel/Buck
+  monorepo shops. Preserves dev velocity; container parity enforced
+  by CI smoke; **mandatory CI runtime test** is the missing-link cost.
+
+aegis-core picks **Camp B**. Reasons:
+
+1. **Architectural consistency.** ADR-0014 (hermetic remote cache),
+   ADR-0015 (hermetic Node.js), CLAUDE.md Rule 6 (hermetic
+   toolchains) already commit the project to Bazel-native
+   reproducibility. Camp A would force every contributor to install
+   Docker Desktop, breaking the "clone, build, it just works" promise.
+2. **Dev velocity.** `bazel run //gateway_go/cmd/gateway:gateway`
+   produces and executes a host-native binary in seconds; the same
+   path through Docker would rebuild image layers on every code
+   change.
+3. **Defensibility.** Camp B's reasoning is the dominant view in the
+   Bazel / SRE-handbook literature; it survives interview scrutiny.
+
+### What runs where
+
+| Action | Dev box | CI |
+| --- | --- | --- |
+| `bazel run //gateway_go/cmd/gateway:gateway` (host-native dev gateway) | ✅ direct exec, no Docker | n/a |
+| `bazel build //packaging/gateway:image` (image-graph build) | ✅ no Docker needed | ✅ part of `bazel-unit-tests` job |
+| `bazel run //packaging/gateway:image_load` + `docker run …` (image runtime smoke) | optional, requires local Docker | ✅ **mandatory CI step** — `--read-only` + `--user 65532:65532` + curl `/healthz` within 10s |
+
+Concretely: Mac contributors **never have to install Docker** to develop, review, or merge changes. CI is the single source of truth for "image actually boots inside a container."
+
+### Mandatory CI runtime smoke — the Camp B keystone
+
+The CI smoke step in `.github/workflows/ci-baseline.yml`
+(`bazel-unit-tests` job) loads the image into the runner's Docker
+daemon, starts it with `--read-only` and `--user 65532:65532`, then
+curls `/healthz` until 200 (10s deadline). This catches:
+
+- Image structure errors (entrypoint path wrong, layer order broken).
+- Static-linking gaps (binary references a libc symbol that distroless
+  doesn't provide).
+- Read-only rootfs violations (binary tries to write `/var/run`
+  without a tmpfs mount).
+- Nonroot user permission errors (binary tries to bind a port < 1024).
+
+Without this step, Camp B's promise is hollow. Removing or weakening
+this gate requires explicit ADR amendment.
+
+## Promotion chain to staging
+
+This ADR's Slice-1 wiring is the **leftmost gate** in a multi-stage
+chain that ends with the image running in staging EKS. The full chain:
+
+| # | Gate | Slice / Phase | What it proves |
+| --- | --- | --- | --- |
+| 1 | CI smoke (this ADR) | 4a-1 | image builds + boots + `/healthz` 200 + read-only rootfs honored |
+| 2 | SBOM emission | 4a-2 | every layer has a CycloneDX SBOM (`ARCHITECTURE.md` §10.1) |
+| 3 | ECR push via OIDC | 4a-3 | image lands in `251774439261.dkr.ecr.eu-central-1.amazonaws.com/aegis-core` |
+| 4 | Trivy CVE scan | 4b | no critical CVE; otherwise push blocked |
+| 5 | Cosign keyless sign | 4b | image signed via GitHub OIDC → Sigstore Fulcio |
+| 6 | K8s manifest tag bump | 4a-3+ | `deployment.spec.containers.image` references the new digest |
+| 7 | ArgoCD sync (ldz repo) | ldz GitOps phase | staging EKS picks up the manifest change |
+| 8 | Kyverno verify-image admission | 4b | rejects pod if Cosign signature absent or invalid |
+| 9 | kubelet startup probe | runtime | EKS itself runs the binary and re-checks `/healthz` |
+
+Slice 1 implements Gate 1 only; subsequent slices and Phase 4b add
+Gates 2–8; Gate 9 is enforced by Kubernetes itself once Phase 4c
+deployment manifests land.
+
+### Honest gap (today, demo horizon)
+
+Between Gate 1 (CI smoke) and Gate 9 (kubelet probe) there is **no
+automated end-to-end test that exercises the deployed staging stack**.
+A regression that escapes CI but doesn't crash the binary on startup
+(e.g. WebRTC handshake silently broken, transcript egress wired to the
+wrong session) lands in staging and is caught only when a human walks
+the demo. That is acceptable at the demo horizon (zero real traffic,
+no SLO commitments) but is not acceptable for production. The closing
+work is tracked in `ROADMAP.md` Phase 4c — "Post-deploy E2E suite
+against staging" + "Synthetic monitoring against staging + prod" —
+and is the prerequisite gate for any path that puts paying users on
+the system.
+
+## Cross-platform compilation — Option C
+
+A related design question for Slice 1 was: how should the gateway
+binary be cross-compiled to Linux/amd64 from Mac dev boxes when
+building the image?
+
+**Selected: explicit named cross-binary target.**
+
+`gateway_go/cmd/gateway/BUILD.bazel` declares two targets:
+
+- `//gateway_go/cmd/gateway:gateway` — `go_binary`, no `pure` /
+  `static` attributes. Default for `bazel run`; produces a host-native
+  binary (Mach-O arm64 on Apple Silicon, ELF amd64 on CI runners
+  and prod). Used for everyday development. **`static = "on"` is
+  intentionally omitted**: rules_go documents it as Linux-only and
+  silently triggers a platform transition to linux_amd64 when set on
+  macOS, which would turn `bazel run :gateway` into a broken
+  Linux-only binary on Mac dev boxes. Pure-Go binaries with no cgo
+  are self-contained on any OS without needing the attribute, and
+  distroless `static-debian12:nonroot` runs them without libc. If a
+  future dep introduces cgo, the cross-compile to linux_amd64 below
+  fails loudly at link time on Mac (no Linux cross C-toolchain) —
+  forcing the discussion before merge.
+- `//gateway_go/cmd/gateway:gateway_linux_amd64` — `go_cross_binary`
+  wrapping `:gateway` with a `linux_amd64` platform transition.
+  Consumed by `//packaging/gateway:image` so the image is **always**
+  a Linux artifact regardless of which host runs `bazel build`. Devs
+  can also `bazel build` this target directly to inspect the Linux
+  ELF without invoking Docker.
+
+Rejected alternatives:
+
+- **A. Implicit (no cross-binary):** image picks up host-platform
+  binary. On Mac dev boxes that produces a darwin binary inside a
+  Linux image — `docker run` fails with "exec format error". Hidden
+  failure mode that violates "clone and run."
+- **B. Force gateway to always be `goos = "linux"`:** breaks the dev
+  workflow on Mac (no native dev binary).
+
+Multi-arch (`gateway_linux_arm64` for Graviton EKS nodepools) and a
+generic `--config=linux-amd64` `.bazelrc` recipe are deliberately
+**not** added in Slice 1 — YAGNI. Each is a sub-10-line addition
+when a concrete consumer materialises (Slice 3 image_index for arm64;
+batch cross-target build flag for Slice 4 engine + Slice 5 frontend).
+
+## Alternatives considered
+
+### Build tool
+
+- **Dockerfile + `docker build`** — rejected. Requires a Docker daemon
+  on every build host (local + CI), violates the hermetic promise, and
+  produces non-reproducible layers because of timestamp drift in
+  `ADD` / `COPY` operations. Bazel's content-addressable model also
+  becomes useless: each `docker build` is opaque to the Bazel cache.
+- **`ko` (Google's Go-native image builder)** — rejected. Excellent
+  for pure-Go monorepos, but only supports Go. We need a single
+  packaging story that works for the C++ engine and the frontend
+  bundle too.
+- **Buildah / kaniko** — rejected. Both eliminate the Docker daemon
+  dependency, but neither integrates with the Bazel action graph. The
+  caching, hermeticity, and reproducibility properties we get from
+  `rules_oci` would have to be reimplemented around the tool.
+
+### Base image
+
+- **`scratch`** — rejected. Zero overhead, but ships no
+  `/etc/passwd`, no CA certificates, no `/tmp`. Adding these manually
+  defeats the simplicity argument; using distroless `static` gets us
+  the same posture with the awkward bits already solved upstream.
+- **Alpine Linux** — rejected. musl libc creates DNS-resolution edge
+  cases (notoriously, Go's `net` package against Alpine's musl) and
+  ships a shell, package manager, and BusyBox utilities that broaden
+  the attack surface for no production benefit.
+- **Wolfi (Chainguard)** — strong runner-up. Daily-rebuilt, signed,
+  glibc-based, SBOM-attached upstream. The reasons we did **not**
+  pick it for the foundation: (a) the Chainguard public images are a
+  marketing surface for the paid product and could change cadence /
+  registry path with limited notice, and (b) distroless has been the
+  Bazel ecosystem's canonical answer for nearly a decade — every
+  `rules_oci` example targets it, every troubleshooting answer
+  assumes it. Reserving Wolfi as a documented re-evaluation when
+  Phase 4b SBOM workflows expose any pain points with the distroless
+  upstream.
+- **Ubuntu / Debian-slim** — rejected. Order-of-magnitude larger
+  attack surface, ships `apt`, ships a shell. No production
+  justification for a Go binary that needs only static linking.
+
+## Consequences
+
+### Positive
+
+- Container packaging inherits Bazel's reproducibility + caching
+  properties end-to-end.
+- BuildBuddy remote cache (ADR-0014) covers image layers
+  automatically; CI cold-build for new images amortises across PRs.
+- Cosign / SLSA / SBOM tooling in Phase 4b plug into a standard OCI
+  artifact, no glue code.
+- Multi-arch (amd64 + arm64) is one extra `platforms = […]` entry,
+  not a separate pipeline.
+
+### Negative
+
+- `rules_oci` v2 is younger than the Aspect / bazel-contrib baseline
+  has been overall; API drift across minor versions is possible.
+  Mitigation: pin to `2.0.1` in `MODULE.bazel`; bumps are explicit
+  PRs with CI smoke-testing the change.
+- Distroless's update cadence is upstream-controlled; we accept their
+  release rhythm. When a CVE-relevant base bump lands, it's a one-line
+  digest change in `MODULE.bazel`.
+- Distroless `static` requires fully static binaries (no CGO). For the
+  Go gateway this is satisfied via `pure = "on"` + `static = "on"` in
+  the `go_binary` rule. The C++ engine (Slice 4) will need a
+  different distroless variant (`base-debian12` or `cc-debian12`) —
+  documented as an open question to revisit when Slice 4 starts.
+
+### Out of scope (this ADR)
+
+- Image tagging conventions for ECR (Slice 3).
+- SBOM attestation format, location, and lifecycle (Slice 2).
+- Cosign keyless signing key management, Fulcio trust roots, and
+  admission-time verification (Phase 4b + landing-zone Kyverno
+  policy).

--- a/docs/incidents.md
+++ b/docs/incidents.md
@@ -1172,6 +1172,150 @@ convenience.
 
 ---
 
+## Incident 12 — `pkg_tar` `remap_paths` silently no-ops; CI smoke fails twice on PR #28
+
+**Date**: 2026-04-19  **Severity**: S4  **Duration**: ~25 min end-to-end (two failed CI runs → local tar inspection → fix)
+**Related commits**: `aa111c4` (initial Slice 1), `c142fb0` (false-fix CI tag), `356201d` (real fix: pkg_files+renames)
+
+### Symptom
+
+Phase 4a Slice 1 introduced an OCI image build for the Go gateway,
+plus a CI smoke step that loads the image into Docker and curls
+`/healthz`. The smoke step failed twice with two different-looking
+errors before resolving.
+
+**Failure A** (`aa111c4`):
+```
+Loaded image: aegis-gateway:dev-local
++ docker run … aegis-gateway:ci-smoke
+Unable to find image 'aegis-gateway:ci-smoke' locally
+docker: Error response from daemon: pull access denied for aegis-gateway,
+  repository does not exist or may require 'docker login'
+```
+
+**Failure B** (`c142fb0`, after first "fix"):
+```
++ docker run … aegis-gateway:dev-local
+docker: Error response from daemon: failed to create task for container:
+  failed to create shim task: OCI runtime create failed: runc create
+  failed: unable to start container process: error during container
+  init: exec: "/usr/local/bin/gateway": stat /usr/local/bin/gateway:
+  no such file or directory
+```
+
+### Root cause
+
+Two separate bugs stacked, with the second one masked by the first.
+
+1. **`oci_load.repo_tags` is not overridable via `bazel run -- <tag>`.**
+   The first CI step did `bazel run //packaging/gateway:image_load --
+   aegis-gateway:ci-smoke`, expecting the trailing argument to set
+   the loaded tag. `oci_load` reads `repo_tags` from its BUILD
+   attribute (hard-coded to `aegis-gateway:dev-local` in our case)
+   and ignores positional argv. Image got loaded under `dev-local`;
+   `docker run aegis-gateway:ci-smoke` then failed because no such
+   tag existed locally.
+
+2. **`pkg_tar`'s `remap_paths` shortcut silently fails on
+   leading-slash mismatch.** The actual binary inside the layer tar
+   was `usr/local/bin/gateway_linux_amd64` (the cross-binary's rule
+   name), not the entrypoint-friendly `gateway`. The original
+   BUILD.bazel declared:
+   ```bzl
+   pkg_tar(
+       …,
+       remap_paths = {
+           "/usr/local/bin/gateway_linux_amd64": "/usr/local/bin/gateway",
+       },
+   )
+   ```
+   Tar entries are conventionally relative (no leading slash), so
+   the rename key never matched any path in the tar — silently. No
+   warning, no error. The image was built with the wrong entrypoint
+   path, and `runc` reported the container init failure only at
+   runtime.
+
+### Detection
+
+Failure A's "pull access denied" was a misleading red herring — the
+real issue was a tag mismatch, not a registry auth problem. Reading
+the line two above (`Loaded image: aegis-gateway:dev-local`)
+made the mismatch visible.
+
+Failure B was caught by extracting the layer tar locally:
+```bash
+tar -tvf bazel-bin/packaging/gateway/gateway_layer.tar
+# usr/local/bin/gateway_linux_amd64   <— wrong filename
+```
+That immediately confirmed the rename did not happen.
+
+A red herring during attempt to fix Failure B: my first `remap_paths`
+correction (removing the leading slash) ran `bazel build` and got
+"up-to-date" — the action cache decided the change wasn't material
+and didn't rebuild. The tar still showed the old filename, but for
+~5 minutes I assumed the fix had taken effect and was confused why
+the path was unchanged. Cache invalidation gotcha.
+
+### Resolution
+
+Two-step fix across two commits:
+
+- `c142fb0`: drop the misleading `bazel run -- <tag>` argv override
+  in CI; reference the BUILD-defined `aegis-gateway:dev-local` tag
+  directly. Comment in the workflow file records why argv override
+  doesn't work.
+- `356201d`: replace `pkg_tar(..., remap_paths = ...)` with the
+  documented `pkg_files(..., renames = ...) → pkg_tar(srcs = …)`
+  pattern. `renames` works on label keys, not tar paths, and is
+  the rules_pkg-recommended mechanism for renaming files inside a
+  package. Local verification: `tar -tvf` now shows
+  `usr/local/bin/gateway` as expected.
+
+### Prevention
+
+- **Use `pkg_files` + `renames` over `pkg_tar.remap_paths` for any
+  rename that matters.** `remap_paths` is the convenient shortcut
+  that fails silently; `pkg_files` is the verbose but correct
+  pattern. The `packaging/gateway/BUILD.bazel` comment block
+  records this tradeoff so future contributors don't re-discover it.
+- **Always `tar -tvf` the output of a packaging rule before
+  building the image on top.** Image-build-then-debug-at-runtime
+  is a slow loop; checking the tar directly is sub-second. This
+  belongs in any future packaging slice's pre-PR checklist.
+- **CI smoke must `set -euxo pipefail`** (already in place in this
+  step) AND echo the tag actually used — the `set -x` trace was the
+  load-bearing diagnostic for Failure A; without it the mismatch
+  would have been invisible in the GitHub Actions log.
+- No new ADR or CI gate warranted. The pattern is documented in
+  `packaging/gateway/BUILD.bazel`; future packaging slices (engine
+  Slice 4, frontend Slice 5) inherit the convention by example.
+
+### Lessons
+
+1. **Convenience APIs that fail silently are worse than verbose
+   APIs that fail loud.** rules_pkg's `remap_paths` is one line
+   shorter than `pkg_files + renames`, but the silent no-op cost
+   ~25 minutes of CI cycles + log-reading. The verbose pattern's
+   extra rule declaration is a one-time cost; the silent-failure
+   class of bug is a recurring tax. Prefer verbose.
+2. **"Fixed locally, build says up-to-date" is a smell.** Bazel's
+   action cache is fast and aggressive; an attribute change that
+   "should" trigger a rebuild but doesn't usually means the change
+   wasn't structurally meaningful (wrong attribute name, wrong
+   key format, no-op edit). Re-extract the actual output file
+   instead of trusting that the build re-ran.
+3. **Two stacked bugs with different-looking errors are
+   indistinguishable from one bug until you fix the first.**
+   Failure A and Failure B were genuinely different root causes,
+   but the workflow ("smoke failed → look at last error → guess →
+   push fix") only surfaces them sequentially. Mitigation: when
+   the surface error changes after a fix, treat it as a NEW
+   incident, not a continuation. Otherwise it's tempting to assume
+   the fix "almost worked" and patch around the new symptom rather
+   than read it cleanly.
+
+---
+
 ## Process notes
 
 - Incidents here cover **development-time** blockers, not a

--- a/gateway_go/cmd/gateway/BUILD.bazel
+++ b/gateway_go/cmd/gateway/BUILD.bazel
@@ -1,5 +1,20 @@
-load("@rules_go//go:def.bzl", "go_binary")
+load("@rules_go//go:def.bzl", "go_binary", "go_cross_binary")
 
+# Default `bazel run :gateway` produces a host-native binary (Mach-O on
+# Mac dev box, ELF on CI / prod Linux runners). Intentionally NO
+# `pure`/`static` attributes here:
+#   - `static = "on"` is rules_go-documented as Linux-only; on macOS
+#     it silently triggers a platform transition to linux_amd64,
+#     turning `bazel run :gateway` into a Linux-only binary that
+#     cannot exec on Apple Silicon — breaks dev workflow (ADR-0025
+#     Camp B / dev-CI split).
+#   - All current deps (grpc-go, protobuf-go, grpcweb, pion/webrtc)
+#     are pure Go with no cgo; the resulting binary is therefore
+#     self-contained on any OS without needing `pure = "on"`. If a
+#     future dep introduces cgo, the cross-compile to linux_amd64
+#     for the OCI image (see :gateway_linux_amd64 below) will fail
+#     loudly at link time on Mac dev boxes — that's a feature,
+#     forcing the discussion before merge.
 go_binary(
     name = "gateway",
     srcs = ["main.go"],
@@ -27,4 +42,19 @@ go_binary(
         "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//keepalive",
     ],
+)
+
+# Explicit linux/amd64 cross-compile target. ADR-0025 Camp B / dev-CI
+# split: //packaging/gateway:image consumes this so the image is always
+# a Linux artifact regardless of the host running `bazel build`. Devs
+# can also `bazel build :gateway_linux_amd64` directly to inspect "what
+# does my code look like as a Linux ELF" without needing Docker.
+#
+# When Slice 3 (multi-arch image_index) lands, sibling targets
+# :gateway_linux_arm64 etc. get added here; YAGNI for Slice 1.
+go_cross_binary(
+    name = "gateway_linux_amd64",
+    platform = "@rules_go//go/toolchain:linux_amd64",
+    target = ":gateway",
+    visibility = ["//visibility:public"],
 )

--- a/packaging/gateway/BUILD.bazel
+++ b/packaging/gateway/BUILD.bazel
@@ -14,21 +14,34 @@
 #   - Cosign / SLSA L3 (Phase 4b)
 
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
-# Layer carrying the gateway binary at /usr/local/bin/gateway.
-# Consumes the explicit linux/amd64 cross-binary (ADR-0025 dev/CI split:
-# image is always a Linux artifact, regardless of host running the
-# build). remap_paths renames the cross-binary's filename
-# `gateway_linux_amd64` to the entrypoint-friendly `gateway` inside the
-# image — pkg_tar materialises DefaultInfo using the rule's name.
+# Stage the gateway cross-binary at /usr/local/bin/gateway via the
+# pkg_files → pkg_tar pattern. We use pkg_files (not pkg_tar's
+# remap_paths shortcut) because:
+#   - pkg_files's `renames` is the documented robust mechanism for
+#     renaming the in-tar file regardless of upstream basename;
+#   - pkg_tar's `remap_paths` matches as a path prefix and is
+#     sensitive to whether the tar entries carry a leading slash —
+#     fragile across rules_pkg versions.
+# The image entrypoint is /usr/local/bin/gateway (clean Unix
+# convention); the underlying cross-binary's filename
+# `gateway_linux_amd64` is an artefact of the go_cross_binary rule
+# name and is hidden from the runtime via this rename.
+pkg_files(
+    name = "gateway_files",
+    srcs = ["//gateway_go/cmd/gateway:gateway_linux_amd64"],
+    attributes = pkg_attributes(mode = "0755"),
+    prefix = "/usr/local/bin",
+    renames = {
+        "//gateway_go/cmd/gateway:gateway_linux_amd64": "gateway",
+    },
+)
+
 pkg_tar(
     name = "gateway_layer",
-    srcs = ["//gateway_go/cmd/gateway:gateway_linux_amd64"],
-    package_dir = "/usr/local/bin",
-    remap_paths = {
-        "/usr/local/bin/gateway_linux_amd64": "/usr/local/bin/gateway",
-    },
+    srcs = [":gateway_files"],
 )
 
 # Compose the image:

--- a/packaging/gateway/BUILD.bazel
+++ b/packaging/gateway/BUILD.bazel
@@ -1,0 +1,71 @@
+# Phase 4a Slice 1 — Go Gateway distroless OCI image (local-only).
+#
+# Strategy in ADR-0025; per-attribute rationale inline below.
+#
+# Targets:
+#   //packaging/gateway:image         — OCI image directory (CI smoke target;
+#                                       no docker daemon needed to build)
+#   //packaging/gateway:image_load    — wraps :image for `docker load`
+#                                       (`bazel run` invokes the loader)
+#
+# NOT in this slice (deferred):
+#   - SBOM generation (Slice 2, Syft + CycloneDX)
+#   - ECR push (Slice 3, GitHub Actions OIDC role)
+#   - Cosign / SLSA L3 (Phase 4b)
+
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+# Layer carrying the gateway binary at /usr/local/bin/gateway.
+# Consumes the explicit linux/amd64 cross-binary (ADR-0025 dev/CI split:
+# image is always a Linux artifact, regardless of host running the
+# build). remap_paths renames the cross-binary's filename
+# `gateway_linux_amd64` to the entrypoint-friendly `gateway` inside the
+# image — pkg_tar materialises DefaultInfo using the rule's name.
+pkg_tar(
+    name = "gateway_layer",
+    srcs = ["//gateway_go/cmd/gateway:gateway_linux_amd64"],
+    package_dir = "/usr/local/bin",
+    remap_paths = {
+        "/usr/local/bin/gateway_linux_amd64": "/usr/local/bin/gateway",
+    },
+)
+
+# Compose the image:
+#   - base: distroless static-debian12:nonroot pulled by digest in MODULE.bazel
+#   - user: "nonroot" — ships as uid 65532; satisfies ROADMAP §Phase 4a
+#     "non-root with dropped capabilities and read-only root filesystem"
+#   - exposed_ports: 8080/tcp (HTTP/healthz) + 9090/tcp (gRPC) match the
+#     current hardcoded listeners in gateway_go/cmd/gateway/main.go;
+#     informational metadata only — kubelet / container runtime ignores it
+#     and a NetworkPolicy is the actual enforcement layer in Phase 4c.
+#   - labels: OCI image-spec annotations consumed by registries, scanners,
+#     and `docker inspect`. Tag-level provenance (git SHA, semver) lands
+#     in Slice 3 alongside ECR push.
+oci_image(
+    name = "image",
+    base = "@distroless_static",
+    entrypoint = ["/usr/local/bin/gateway"],
+    exposed_ports = [
+        "8080/tcp",
+        "9090/tcp",
+    ],
+    labels = {
+        "org.opencontainers.image.source": "https://github.com/BinHsu/aegis-core",
+        "org.opencontainers.image.title": "aegis-gateway",
+        "org.opencontainers.image.description": "Aegis Gateway — gRPC + gRPC-Web + WebRTC entry point.",
+        "org.opencontainers.image.licenses": "Apache-2.0",
+    },
+    tars = [":gateway_layer"],
+    user = "nonroot",
+    visibility = ["//visibility:public"],
+)
+
+# Local smoke: `bazel run //packaging/gateway:image_load` loads the image
+# into the host docker daemon under the tag below. Not invoked by CI —
+# CI builds :image directly (no docker daemon on the runner needed).
+oci_load(
+    name = "image_load",
+    image = ":image",
+    repo_tags = ["aegis-gateway:dev-local"],
+)


### PR DESCRIPTION
## Summary

First wiring slice for **Phase 4a OCI packaging**. Adds `rules_oci` v2.0.1 + `rules_pkg` v1.0.1, pulls distroless `static-debian12:nonroot` by SHA256 manifest-list digest, and produces `//packaging/gateway:image` — a distroless OCI image of the Go Gateway running as nonroot (uid 65532) with ports 8080/9090 exposed.

**Strategy**: ADR-0025. Camp B (dev = direct binary, CI = container validation), `rules_oci` over `Dockerfile`/`ko`/`Buildah`, distroless static-debian12 over `scratch`/Alpine/Wolfi, digest-pinning, non-root posture.

**Cross-platform** (Option C): `:gateway` stays host-native (Mach-O on Mac, ELF on CI/prod) so `bazel run :gateway` for dev workflow is unchanged; `:gateway_linux_amd64` (`go_cross_binary`) feeds the image so it's always a Linux artifact regardless of host. `static="on"` intentionally NOT on the base — rules_go silently transitions Mac builds to Linux when set, breaking dev (documented in ADR-0025 §"Cross-platform compilation").

## What this PR does

- `MODULE.bazel`: activate `rules_oci` + `rules_pkg`; pull `distroless_static` by digest (`sha256:a9329520…c109fd1`, multi-arch amd64 + arm64/v8)
- `gateway_go/cmd/gateway/BUILD.bazel`: add `:gateway_linux_amd64` cross-binary; base `:gateway` stays host-native
- `packaging/gateway/BUILD.bazel` (new): `pkg_tar` → `oci_image` (nonroot, OCI labels, exposed ports) → `oci_load` (CI smoke uses, dev optional)
- `docs/adr/0025-oci-packaging-strategy.md` (new): full architectural rationale incl. promotion-chain map + honest gap section
- `.github/workflows/ci-baseline.yml`: bazel-unit-tests job extended with (1) build of `:image` and (2) `docker run --read-only --user 65532:65532 …` + `curl /healthz` smoke. **No new job; matrix stays at 8.**
- `ROADMAP.md`: per-slice expansion of Phase 4a checklist; new Phase 4c entries for **post-deploy E2E suite** + **synthetic monitoring** (honest Known Gap)
- `ARCHITECTURE.md`: §10.1.1 added on OCI image construction posture

## Out of scope (deferred to later slices)

- **Slice 4a-2**: SBOM via Syft / CycloneDX
- **Slice 4a-3**: GitHub Actions ECR push via `github-actions-aegis-core-ecr` OIDC role — gated on [aegis-aws-landing-zone#75](https://github.com/BinHsu/aegis-aws-landing-zone/issues/75) confirming `terraform-apply-baseline.yml` ran since ldz PR #74
- **Slice 4a-4**: C++ engine image (different distroless variant for hermetic clang × dynamic-lib story)
- **Slice 4a-5**: Frontend image (static asset packaging)
- **Phase 4b**: Cosign keyless sign + SLSA L3 + Trivy scan

## Test plan

- [x] **Local Mac M-series** (no Docker required):
  - [x] `:gateway` → `Mach-O 64-bit executable arm64` (host-native preserved)
  - [x] `:gateway_linux_amd64` → `ELF 64-bit LSB statically linked` (correct cross)
  - [x] `:image` → `bazel-bin/packaging/gateway/image/{blobs,index.json,oci-layout}` (OCI directory builds)
  - [x] Cold full build (rules_oci + rules_pkg + distroless pull): ~30s
- [ ] **CI** (validates everything Mac dev can't):
  - [ ] All 8 existing jobs stay green (no regression)
  - [ ] New CI step: `:image` builds on ubuntu-latest
  - [ ] New CI smoke step: `docker run --read-only` boots image; `curl /healthz` returns 200 within 10s
  - [ ] BuildBuddy cache key auto-rotates (MODULE.bazel hash changed); subsequent runs hit cache

## Promotion-chain note

This PR implements **Gate 1** (CI smoke) of the multi-stage chain to staging. ADR-0025 §"Promotion chain to staging" maps all 9 gates. **Honest gap noted**: between Gate 1 and Gate 9 (kubelet probe) there's no automated E2E against the deployed staging stack today — only human walk-through. ROADMAP Phase 4c now tracks the closing work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)