### PR TITLE
fix(deps): Go SDK 1.24.12 → 1.24.13 — fixes CVE-2025-68121 (Trivy first real catch)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -148,8 +148,12 @@ go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 
 # Pinned >= 1.24.12 because gazelle 0.50.0's go_repository_tools has a
 # go.work requiring go >= 1.24.12 (running lower errors out during
-# external repo setup). Bump gazelle to go along.
-go_sdk.download(version = "1.24.12")
+# external repo setup). Bumped to 1.24.13 (2026-04-19) per Trivy
+# CRITICAL finding CVE-2025-68121 — crypto/tls incorrect certificate
+# validation during TLS session resumption (fixed in 1.24.13). Phase 4b
+# mini-slice 2 caught this on its first real run; demonstrates the
+# scan-on-push gate doing its job. ADR-0029.
+go_sdk.download(version = "1.24.13")
 
 # go_deps extension resolves gateway_go/go.mod into Bazel repositories
 # so rules_go targets can depend on Go module deps like grpc-go and


### PR DESCRIPTION
## Summary

Phase 4b mini-slice 2 (Trivy CVE block, ADR-0029) on its first real release-workflow run found **CVE-2025-68121** in the Go stdlib of the gateway image. CRITICAL severity, fix available in Go 1.24.13. Bumping `go_sdk.download(version = …)` in `MODULE.bazel`.

```
Library: stdlib
Vulnerability: CVE-2025-68121
Severity: CRITICAL
Installed: 1.24.12
Fixed: 1.24.13, 1.25.7, 1.26.0-rc.3
Title: crypto/tls: Incorrect certificate validation during TLS
       session resumption
```

## Why this is the right kind of failure

This commit is the **end-to-end demonstration** ADR-0029 commits to:

1. Trivy scans on every release push
2. CRITICAL CVE with available upstream fix → workflow blocks
3. Operator bumps the dep
4. Re-scan passes
5. Image lands signed + scanned + provenance-attested

Trivy did its job — caught a real production-relevant CVE before it would have shipped to staging.

## Verification

- [x] Local: `bazel build //gateway_go/cmd/gateway:gateway` succeeds with Go 1.24.13 (cold rebuild 61s)
- [ ] PR-level CI: 8 ci-baseline jobs stay green (Bazel rebuilds Go SDK)
- [ ] Post-merge: release workflow runs full Cosign + Trivy + SLSA chain on both gateway + engine; expected GREEN this time

## Cross-references

- ADR-0029 (Trivy + SLSA, just landed in PR #41)
- Failed release workflow run that found this: https://github.com/BinHsu/aegis-core/actions/runs/24632558564
- Go security advisory: https://avd.aquasec.com/nvd/cve-2025-68121

🤖 Generated with [Claude Code](https://claude.com/claude-code)