### PR TITLE
test(engine): ADR-0005 R7 — AEGIS_DEV_AUDIO_DUMP binary grep gate

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # 🗺️ Aegis Core (V2) — Roadmap
 
 **Current Status**: Architecture design complete; implementation bootstrapping pending.
-**Last Updated**: 2026-04-19 (Phase 4a EXITED — all 5 slices landed: rules_oci wiring + Go GW image + CI smoke + CycloneDX SBOM + ECR push + C++ engine image + S3+CloudFront frontend; Phase 4b mini-slice 1 also landed: Cosign keyless image signing + signed SBOM attestation. ADRs 0025 / 0026 v2 + Revision / 0027 / 0028 capture the design pivots driven by this session's reviews.)
+**Last Updated**: 2026-04-20 (Phase 4b residual tick — `AEGIS_DEV_AUDIO_DUMP` CI gate landed as Bazel `sh_test` under `//engine_cpp/tests/unit/`, grep-based binary check per ADR-0005 R7. Prior 2026-04-19 snapshot: Phase 4a EXITED — all 5 slices landed; Phase 4b mini-slices 1–3 landed: Cosign keyless signing + Trivy CRITICAL-CVE block + SLSA L3 provenance. ADRs 0025 / 0026 v2 + Revision / 0027 / 0028 / 0029 capture the design pivots.)
 
 This roadmap reflects the architectural decisions captured in
 `ARCHITECTURE.md` and the ADRs in `docs/adr/`. Before working on any
@@ -317,12 +317,10 @@ Gated by 3b — prompter display needs real transcript data; corpus selector nee
 - [x] Cosign / Sigstore signing in GitHub Actions using OIDC (ARCH §10.1) — keyless via `sigstore/cosign-installer` SHA-pinned in `release-staging-image.yml`. Both gateway + engine images signed by manifest digest after push; gateway SBOM (Slice 4a-2's CycloneDX) attached as signed CycloneDX attestation; Rekor public transparency log records every signing event. ADR-0028 documents the Sigstore + keyless choice. Engine SBOM attestation deferred (engine SBOM gen still pending — separate mini-slice). Verification side handed to ldz via cross-repo issue for Kyverno verify-image admission in EKS.
 - [x] SLSA Level 3 provenance emission (ADR-0029) — `actions/attest-build-provenance` SHA-pinned generates in-toto v1 statements per image (gateway + engine), referencing exact Git commit + GitHub-hosted runner + workflow path. Pushed to ECR alongside the image as an OCI attestation artifact + stored in the GitHub attestation store. Same OIDC trust scope as Cosign; Kyverno admission (ldz #96) can validate both signed AND SLSA-attested.
 - [x] Trivy container scan; block push on critical CVEs (ADR-0029) — `aquasecurity/trivy-action` SHA-pinned scans gateway + engine images by `@sha256:` digest after push (no tag-race), `severity: CRITICAL` + `ignore-unfixed: true` initial threshold; `exit-code: 1` blocks workflow on CRITICAL findings. Tighten to `HIGH,CRITICAL` is a one-line change when ops bandwidth supports the triage.
-- [ ] SLSA Level 3 provenance emission
-- [ ] Trivy container scan; block push on critical CVEs
+- [x] Verify no binary contains `AEGIS_DEV_AUDIO_DUMP` symbol (ADR-0005 R7) — Bazel `sh_test` `//engine_cpp/tests/unit:no_dev_audio_dump_symbol_test` greps the linked engine binary for the string; passes in default fastbuild, fails under `--config=debug`. Included in PR CI via `ci-baseline.yml` → `bazel test`; `--strip=always` on release strips symbols but not `.rodata`, so the string survives stripping and the gate still detects leaked copts.
 - [ ] kube-score + kube-bench manifest scan
 - [ ] Checkov IaC scanner for K8s manifests + Dockerfile + Helm charts (complements kube-score/kube-bench from the misconfiguration / policy-as-code angle; see debrief discussion 2026-04-12)
 - [ ] CodeQL, Semgrep, gosec, govulncheck, clang-tidy in CI (ARCH §10.2)
-- [ ] Verify no binary contains `AEGIS_DEV_AUDIO_DUMP` symbol (ADR-0005 R7)
 - [ ] ECR push pipeline; ArgoCD in `aegis-aws-landing-zone` repository polls the manifests in this repository
 
 ### Phase 4c: Progressive Delivery

--- a/docs/adr/0005-audio-ephemeral-policy.md
+++ b/docs/adr/0005-audio-ephemeral-policy.md
@@ -261,9 +261,17 @@ by accident or malice.
 - Go debug audio dump code is gated by a build tag
   `//go:build aegis_dev_audio_dump`. Release builds do not include the
   tag.
-- Container images tagged `prod-*` are built with release flags and
-  verified via a CI check: `grep "AEGIS_DEV_AUDIO_DUMP" on the binary`
-  must return empty for prod images.
+- Enforcement target:
+  `//engine_cpp/tests/unit:no_dev_audio_dump_symbol_test` (sh_test).
+  Greps the linked engine binary for `AEGIS_DEV_AUDIO_DUMP`. Default
+  `bazel test` runs in fastbuild (no define set) so the string is
+  absent and the test passes. If a `-DAEGIS_DEV_AUDIO_DUMP` copt
+  leaks into any non-debug build path, the `#ifdef`-guarded banner
+  string at `engine_cpp/cmd/engine/main.cc:138-145` lands in
+  `.rodata` and the grep matches. `--strip=always` on release
+  (`.bazelrc:82`) removes symbol tables but NOT `.rodata`, so the
+  string survives stripping and the gate catches it. Included in
+  the PR CI matrix via `ci-baseline.yml` → `bazel test`.
 - CI gate: any PR that introduces a runtime toggle (environment
   variable, CLI flag, config file key) for audio dumping is flagged
   for human security review.

--- a/engine_cpp/tests/unit/BUILD.bazel
+++ b/engine_cpp/tests/unit/BUILD.bazel
@@ -77,3 +77,15 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+# ADR-0005 R7 — release binaries MUST NOT ship the AEGIS_DEV_AUDIO_DUMP
+# debug banner. Default `bazel test` builds engine in fastbuild → no
+# define → string absent → pass. Fails if a -DAEGIS_DEV_AUDIO_DUMP
+# copt leaks outside the `build:debug` config in .bazelrc.
+sh_test(
+    name = "no_dev_audio_dump_symbol_test",
+    srcs = ["no_dev_audio_dump_test.sh"],
+    size = "small",
+    args = ["$(rootpath //engine_cpp/cmd/engine:engine)"],
+    data = ["//engine_cpp/cmd/engine:engine"],
+)

--- a/engine_cpp/tests/unit/no_dev_audio_dump_test.sh
+++ b/engine_cpp/tests/unit/no_dev_audio_dump_test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# ADR-0005 R7 enforcement: release binaries MUST NOT ship the
+# AEGIS_DEV_AUDIO_DUMP debug banner.
+#
+# main.cc:138-145 guards a cerr banner with `#ifdef AEGIS_DEV_AUDIO_DUMP`.
+# When -DAEGIS_DEV_AUDIO_DUMP is set (only under `--config=debug` per
+# .bazelrc:80), the #ifdef block compiles in and the banner string
+# "AEGIS_DEV_AUDIO_DUMP is enabled" lands in .rodata. `--strip=always`
+# on release strips symbol tables but NOT .rodata, so the string
+# survives and this grep still catches accidental leakage.
+#
+# Default `bazel test` is fastbuild (no define) — passes. Test fails
+# if any build path outside `--config=debug` smuggles the copt in.
+
+set -euo pipefail
+
+BIN="${1:?binary path missing — invoke via sh_test with data = [:engine]}"
+
+if [[ ! -f "$BIN" ]]; then
+  echo "FAIL: binary not found at $BIN" >&2
+  exit 1
+fi
+
+if LC_ALL=C grep -a -q "AEGIS_DEV_AUDIO_DUMP" "$BIN"; then
+  cat >&2 <<EOF
+FAIL: ADR-0005 R7 violation — binary contains AEGIS_DEV_AUDIO_DUMP string.
+
+The #ifdef-gated debug banner leaked into a non-debug build. Somewhere
+-DAEGIS_DEV_AUDIO_DUMP is being applied outside \`build:debug\`. Inspect
+.bazelrc, per-target copts, and any --copt flags on the invoking CI
+command line.
+
+Banner source : engine_cpp/cmd/engine/main.cc:138-145
+Defining flag : .bazelrc:80 (build:debug --copt=-DAEGIS_DEV_AUDIO_DUMP)
+Binary checked: $BIN
+EOF
+  exit 1
+fi
+
+echo "OK: ADR-0005 R7 satisfied — no AEGIS_DEV_AUDIO_DUMP string in $BIN"


### PR DESCRIPTION
## Summary

Phase 4b residual — enforces at CI-time that release binaries do NOT ship the `#ifdef AEGIS_DEV_AUDIO_DUMP`-guarded debug banner from `engine_cpp/cmd/engine/main.cc:138-145`.

- New Bazel `sh_test`: `//engine_cpp/tests/unit:no_dev_audio_dump_symbol_test` — greps the linked engine binary for the macro name literal (the banner string containing the macro name, which lives in `.rodata`).
- `grep -a` over `strings` — POSIX, no binutils dependency.
- `--strip=always` on release strips symbol tables but NOT `.rodata`, so the gate still catches leaked copts.
- ROADMAP.md: tick the R7 line + drop two stale `[ ]` duplicates of SLSA L3 + Trivy (already `[x]` two lines above after #41).
- ADR-0005 §Enforcement: point R7 at the concrete test target + explain strip/rodata mechanics.

## Test plan

Already run locally per CLAUDE.md Rule 2 (real inputs, verifiable outputs):

- [x] **Positive** — default fastbuild, no `-DAEGIS_DEV_AUDIO_DUMP`: `bazel test //engine_cpp/tests/unit:no_dev_audio_dump_symbol_test` → `PASSED in 0.9s`
- [x] **Negative** — `--config=debug` applies the copt: same test → `FAILED in 0.2s` with the scripted diagnostic ("binary contains AEGIS_DEV_AUDIO_DUMP string"). Confirms the gate is not a tautology.
- [ ] CI `ci-baseline.yml` → `bazel test //engine_cpp/tests/unit/...` picks the target up automatically (no tag filter exclusion).
- [ ] `release-staging-image.yml` inherits the gate transitively — main cannot carry a state that fails PR CI.

## Why grep not strings

The preprocessor macro itself never reaches the binary; what reaches `.rodata` is the `cerr` banner string that contains the macro name. `grep -a` treats binary as text and has zero toolchain dependency (no binutils `strings` needed in the Bazel test runner env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)