### PR TITLE
feat(phase2): LAN live transcript — three-layer Incident 14 fix + test-first discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,9 @@
 
 2. **Testing Integrity**
    * Code must have legitimate tests. Do NOT write stub tests that just `return true` or `assert(1 == 1)` to get a green light. Real inputs must produce verifiable real outputs.
+   * **Test-first commit discipline.** For any bug that a unit or integration test *could have caught*, write the regression test **in the same commit / PR as the fix**, and verify the test is actually load-bearing (it fails on the pre-fix code, passes on the post-fix code). Do NOT commit the fix alone on the promise of a follow-up test — follow-ups decay, and the next regression of the same shape lands unnoticed. Incident 14 (2026-04-20 LAN transcript three-layer bug) is the canonical case: the `WebSocketTranscriptStreamProvider` dropping binary frames was a 10-line Vitest away from being caught in Phase 1; not having it cost hours.
+   * **Testing escape hatches must be named explicitly.** Some bugs are genuinely beyond UT scope — cross-process protocol timing (gRPC keepalive policy, HTTP/2 GOAWAY cadence), OS-level behaviors, hardware-dependent code paths. When declining to write a UT for a specific bug, the PR body MUST say so AND explain what layer *could* catch it (e.g., "long-running staging canary"). Silent omission is how Rule 2 rots over time.
+   * **Local `bazel test` MUST be green before `git commit`.** Pre-commit hooks cover lint and format; they do NOT run full test suites. The author is responsible for `./tools/bazelisk/bazelisk test //...` (or the relevant scoped subset) passing locally before the commit, not merely before the PR merge. "CI will catch it" is a valid safety net, not a valid substitute for the discipline.
 
 3. **Mandatory Documentation Synchronization**
    * Before writing code, you MUST read `ARCHITECTURE.md` and `ROADMAP.md`.

--- a/docs/incidents.md
+++ b/docs/incidents.md
@@ -1401,6 +1401,72 @@ INFO: Build completed successfully, 1 total action
 
 ---
 
+## Incident 14 — LAN transcript pipeline silently lost at the last hop (Phase-1 WS decoder stub)
+
+**Date**: 2026-04-20  **Severity**: S3  **Duration**: ~3 hours (plus ≈ 2 hours burned on the wrong layers first — see §Detection)
+**Related commit**: *this commit*
+
+### Symptom
+
+End-to-end LAN smoke (`bazel run //:app_local --with-frontend`) produced no transcript text on the Host page, despite:
+
+- Whisper model loading cleanly (engine log showed `compute buffer (decode) = 95.91 MB`).
+- WebRTC peer reaching `connected` in `chrome://webrtc-internals` (confirmed ICE candidate pair, `active=true` outbound-rtp, bytes flowing).
+- Gateway receiving audio, forwarding to engine's `StreamTranscribe` stream.
+
+Host UI permanently read `Waiting for the first segment…`. Speaking for a minute changed nothing.
+
+### Root cause
+
+Three stacked bugs, each hiding the next:
+
+1. **Engine gRPC server had no keepalive policy**, and the gateway's client keepalive sends pings every 30 s (ADR-0006). gRPC C++ default rejects pings more frequent than 5 minutes → `ENHANCE_YOUR_CALM` / `too_many_pings` → GOAWAY → reconnect → engine reloads the whisper model from scratch → repeat every ≈ 4 minutes. Fixed by `GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS=20000` + `GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS=1` on the C++ `ServerBuilder`.
+2. **Engine's `Session::Run` was batch-transcribe-only**, not streaming. It accumulated PCM into a `std::vector<float>` for the entire session and called `engine->Transcribe(samples)` **once** after the stream closed (Stage 5 in `session.cc`). So live listeners never saw anything until EndMeeting, and even then the single segment was emitted on a stream that the gateway had already torn down → client missed it. Fixed by adding a live-window flush helper (`kLiveWindowSamples = 3 s × 16 kHz`) that calls `Transcribe` + `EmitTranscriptSegments` mid-loop, non-overlapping, with monotonic `segment_id` + derived `start_ms/end_ms`.
+3. **`WebSocketTranscriptStreamProvider` was a Phase-1 stub that only handled string frames.** The gateway sends binary protobuf frames (`websocket.MessageBinary`, `proto.Marshal(ViewerEvent)`); the browser received the `ArrayBuffer`, checked `typeof ev.data === "string"`, saw `false`, and **silently discarded every frame**. The in-file comment literally said "Phase 2 decodes real protobuf" — never happened. Fixed by importing `@bufbuild/protobuf` + the generated `ViewerEvent` class, calling `ViewerEvent.fromBinary(new Uint8Array(ev.data))`, mapping proto enums / bigint fields back to the UI's light-weight `ViewerEvent` shape in `types.ts`, and calling `callbacks.onEvent`.
+
+Bug 1 masked bug 2: with the stream dying every 4 minutes, nobody noticed `Session::Run`'s batch shape because the session never *ran* long enough to reach Stage 5. Bug 2 masked bug 3: with no segments emitted in the first place, nobody noticed the WS frames were being dropped by the browser. Observability gaps (the pipeline + webrtc Go packages had **zero** `slog` calls, and `runEgress` swallowed non-EOF errors with a bare `return`) made all three bugs equally invisible — the surface symptom was always the same: empty UI.
+
+### Detection
+
+Four wrong-layer probes before the real diagnosis:
+
+1. **Chrome `webrtc-internals`** confirmed PC reached `connected`, bytes flowing — ruled out media layer.
+2. **`chrome://webrtc-internals` stats graph** showed non-zero `bytesSent_in_bits/s` on speech — ruled out mic / codec negotiation.
+3. **`nc -l 8888` + phone GET** showed LAN firewall was not blocking 8080 — ruled out macOS Application Firewall.
+4. **Host UI UX audit** surfaced two unrelated UX gaps (React state not subscribing to PC `connectionState`, RAG dropdown showing 4 fake corpora) that delayed the real diagnosis because they looked plausible as primary bugs.
+
+The first real signal came from `curl :8081/metrics | grep aegis_gateway`: `aegis_gateway_active_sessions=1` and `CreateMeeting ok=1`, but no counter for `StreamTranscribe` ingest beyond that — triggering the `grep -rn 'slog\.' gateway_go/internal/{pipeline,webrtc,grpc}/` that turned up **zero log statements** across the audio path. Adding `pipeline.engine.stream_opened`, `pipeline.engine.first_egress_message`, `pipeline.engine.stream_closed_{eof,err}`, and `pipeline.broadcast.transcript{,_no_subscribers}` (all Info, all carry `session_id`) made every layer of the bug sequentially visible in the next run:
+
+- `ENHANCE_YOUR_CALM` GOAWAY appeared in `[gateway]` log → caught bug 1.
+- After bug 1's fix, `first_egress_message` did not fire despite session running for 60 s → caught bug 2 (batch shape — `Session::Run` never reached Stage 5 while the client was subscribed).
+- After bug 2's fix, `broadcast.transcript delivered=1 dropped=0` fired every 3 s but UI still empty → final layer, bug 3 (WS stub).
+
+### Resolution
+
+One commit, three logically-separable fixes:
+
+- `engine_cpp/cmd/engine/main.cc` — two `AddChannelArgument` lines to permit the gateway's 30 s keepalive ping cadence.
+- `engine_cpp/src/session/session.cc` — `flush_window()` helper called on every OPUS / PCM append; non-overlapping 3 s window emits mid-stream; Stage 5 becomes a force-flush of the trailing sub-window.
+- `frontend_web/src/providers/TranscriptStreamProvider/WebSocketTranscriptStreamProvider.ts` — full binary-frame decoder via `@bufbuild/protobuf` `ViewerEvent.fromBinary`, mapped to UI types with `exactOptionalPropertyTypes`-safe conditional spread.
+
+Plus the load-bearing observability layer that made the whole sequence diagnosable in one more run: `pipeline.go` / `negotiator.go` `slog` calls keyed on `session_id`, `runEgress` error path no longer silent, `Broadcast` return values used (`delivered, dropped`).
+
+### Prevention
+
+- **Every cross-process boundary carries `session_id` in its log context.** Future customer-support debugging on EKS will be `kubectl logs | grep session_id=...` across gateway + engine pods; this incident fixed the gateway side, engine-side C++ logger session-id tagging is a follow-up in ROADMAP Phase 4d.
+- **`runEgress` error path now logs with the error text and the accumulated counters.** Any future engine-side failure — OOM, whisper crash, context cancel — surfaces as a `pipeline.engine.stream_closed_err` at Warn level with full context. No more bare `return`.
+- **"TODO: Phase 2 decode real protobuf" is a lethal marker.** The file's TODO dated back to Phase 1 and was skipped over in subsequent reviews because nobody was exercising LAN-mode with real audio. Lesson in §Lessons below.
+
+### Lessons
+
+1. **Three misattributions cost ~2 h.** WebRTC-internals, firewall probe, React-state UI audit were each plausible *given the symptom* but each explored a layer that wasn't broken. The lesson from Incident 13 (reach for `--explain` earlier) applies here in a different form: when a pipeline stalls silently, **go add observability to every hop before debugging any one hop**. The `pipeline.engine.first_egress_message` log took 10 lines to add and resolved the first real ambiguity in one run.
+2. **Silent `return` on error is worse than a panic.** `runEgress`'s pre-fix behavior (`if err == io.EOF { return }; return`) swallowed EVERY engine-side failure including context cancellation due to keepalive timeout. Had this emitted a Warn from day one, bug 1 would have been named in the first session. Enforce: **every error branch logs at Warn or higher with enough context to identify the session**.
+3. **"Phase-N stub" markers accumulate risk.** `WebSocketTranscriptStreamProvider` carried its "decodes real protobuf in Phase 2" comment across 3 releases because the ws/viewer path wasn't exercised end-to-end until today. Two process implications: (a) PR reviews should flag any *stub* with no tracking issue, not just any *TODO*; (b) a first-user-exercise of a code path should be treated as a test, not a demo. A 10-line `ws-decode-smoke.test.ts` that sent a known ViewerEvent through the provider and asserted on the parsed shape would have caught this in Phase 1.
+4. **Observability debt compounds non-linearly.** Pipeline + webrtc + grpc packages had 0 log statements each. Debugging the three-layer bug required *all three* packages to report what they saw; adding logs to one while leaving the others silent would just move the mystery. Paying the observability tax on a Go package is cheap and should not be deferred past "code is functional" — it should be a gate at "code is reviewable".
+5. **End-to-end demo is the first real test of a LAN-mode stack.** Before today, `bazel run //:app_local` had never been driven with a human talking into a mic into the host UI until the transcript appeared. Every lower-level test (unit, integration) was stubbing out the layer above. The demo itself became the detector — acceptable for a solo project, **unacceptable at team scale**. ROADMAP Phase 4d's "Post-deploy E2E suite against staging" (Playwright happy-path) is the structural fix; that slice just gained a clear use-case from this incident.
+
+---
+
 ## Process notes
 
 - Incidents here cover **development-time** blockers, not a

--- a/engine_cpp/cmd/engine/main.cc
+++ b/engine_cpp/cmd/engine/main.cc
@@ -175,6 +175,18 @@ int main(int argc, char **argv) {
   builder.AddListeningPort(address, ::grpc::InsecureServerCredentials());
   builder.RegisterService(&service);
 
+  // Keepalive policy — MUST accept the gateway client's 30s PING cadence
+  // (see `gateway_go/cmd/gateway/main.go` keepaliveTime per ADR-0006).
+  // gRPC C++ server defaults reject pings more frequent than 5 minutes
+  // and disallow pings without active calls; under default the gateway's
+  // 30s PINGs trigger ENHANCE_YOUR_CALM GoAway + reconnect every ~4 min,
+  // causing WhisperEngine::Create to reload the model from scratch every
+  // cycle and transcript segments never complete (observed 2026-04-20 in
+  // LAN smoke). Accept PING every 20s even without active calls.
+  builder.AddChannelArgument(
+      GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS, 20000);
+  builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+
   g_server = builder.BuildAndStart();
   if (!g_server) {
     std::cerr << "aegis-engine: failed to start gRPC server on " << address

--- a/engine_cpp/src/session/session.cc
+++ b/engine_cpp/src/session/session.cc
@@ -26,6 +26,22 @@ namespace {
 // SessionStart.estimated_bytes overrides if set.
 constexpr std::size_t kDefaultReservationBytes = 200ULL * 1024 * 1024;
 
+// Live-transcribe window size (MVP).
+//
+// 3 seconds @ 16 kHz mono = 48000 samples. Trade-off summary:
+//   - Smaller window → lower latency to first segment, worse whisper
+//     accuracy (whisper's encoder was trained for ~30 s windows).
+//   - Larger window → better accuracy, higher first-segment latency,
+//     higher per-session peak memory.
+// 3 s is the cheapest "live" cadence that still produces usable
+// transcription on tiny.en. No overlap is kept for MVP — words may
+// cut at window boundaries; VAD-based boundary selection is Phase 2+.
+// Final-flush at stream end (below) emits the remaining < window
+// sub-window so no audio is lost on EndMeeting.
+constexpr std::size_t kSampleRateHz = 16000;
+constexpr std::size_t kLiveWindowSeconds = 3;
+constexpr std::size_t kLiveWindowSamples = kLiveWindowSeconds * kSampleRateHz;
+
 enum class State {
   WaitingForStart,
   Active,
@@ -48,7 +64,8 @@ void AppendInt16LEAsFloat(const std::string &int16_le_bytes,
 }
 
 absl::Status EmitTranscriptSegments(
-    const std::string &text,
+    const std::string &text, std::uint64_t segment_id, std::int64_t start_ms,
+    std::int64_t end_ms,
     ::grpc::ServerReaderWriter<aegis::v1::EgressMessage,
                                aegis::v1::IngestMessage> *stream) {
   if (text.empty()) {
@@ -56,10 +73,10 @@ absl::Status EmitTranscriptSegments(
   }
   aegis::v1::EgressMessage egress;
   auto *seg = egress.mutable_transcript();
-  seg->set_segment_id(1);
+  seg->set_segment_id(segment_id);
   seg->set_speaker_label("Speaker_0"); // single-stream Phase 1
-  seg->set_start_ms(0);
-  seg->set_end_ms(0);
+  seg->set_start_ms(start_ms);
+  seg->set_end_ms(end_ms);
   seg->set_text(text);
   seg->set_language("en");
   seg->set_is_final(true);
@@ -67,7 +84,7 @@ absl::Status EmitTranscriptSegments(
   seg->set_confidence(0.0f);
   if (!stream->Write(egress)) {
     return absl::AbortedError(
-        "Session: client closed stream before final write");
+        "Session: client closed stream before transcript write");
   }
   return absl::OkStatus();
 }
@@ -117,16 +134,68 @@ Session::Run(::grpc::ServerReaderWriter<aegis::v1::EgressMessage,
   auto engine = std::move(*engine_or);
 
   // Stage 4 — state machine over IngestMessage stream.
+  //
+  // Live windowing model (MVP):
+  //   - samples accumulates incoming PCM.
+  //   - Whenever samples.size() crosses kLiveWindowSamples, flush_window()
+  //     runs Transcribe + Emit + clears the buffer (non-overlapping).
+  //   - After the stream ends (END_STREAM or client close), a final
+  //     force-flush emits whatever sub-window remains.
+  // Each emitted segment carries start_ms/end_ms derived from the
+  // cumulative sample offset, so viewers can align transcript text to
+  // real wall-clock positions. segment_id is a session-local monotonic
+  // counter.
   State state = State::Active;
   std::vector<float> samples;
-  // Pre-reserve ~30 seconds of 16 kHz mono to avoid mid-loop rallocs.
-  samples.reserve(30 * 16000);
+  samples.reserve(kLiveWindowSamples + kSampleRateHz);
+
+  std::uint64_t next_segment_id = 1;
+  std::uint64_t samples_emitted = 0; // total samples already covered by
+                                     // an emitted segment (for timestamps)
 
   // OpusDecoder is lazy-init on the first OpusChunk — sessions that
   // stream only PcmChunk (WAV fixture replay, push-to-talk) never pay
   // the libopus setup cost. Per ADR-0016 one instance per session;
   // libopus carries PLC state across calls.
   std::unique_ptr<aegis::audio::OpusDecoder> opus_decoder;
+
+  // flush_window — if samples has accumulated at least one full window
+  // (or force=true for end-of-stream flush), Transcribe it, emit a
+  // segment (with start_ms/end_ms computed from samples_emitted), then
+  // clear samples. Transcribe errors are swallowed so a single bad
+  // window does not tear the session down — this mirrors the ADR-0016
+  // "log-and-drop" stance on per-frame Opus decode errors.
+  auto flush_window = [&](bool force) -> absl::Status {
+    if (samples.empty()) {
+      return absl::OkStatus();
+    }
+    if (!force && samples.size() < kLiveWindowSamples) {
+      return absl::OkStatus();
+    }
+    const std::size_t window_n = samples.size();
+    auto text_or = engine->Transcribe(samples);
+    samples.clear();
+    const std::int64_t start_ms =
+        static_cast<std::int64_t>((samples_emitted * 1000) / kSampleRateHz);
+    samples_emitted += window_n;
+    const std::int64_t end_ms =
+        static_cast<std::int64_t>((samples_emitted * 1000) / kSampleRateHz);
+    if (!text_or.ok()) {
+      // Log-and-drop this window; continue the session.
+      return absl::OkStatus();
+    }
+    if (text_or->empty()) {
+      // Whisper produced silence — do not emit an empty segment. The
+      // segment_id is NOT incremented; it only counts emitted segments.
+      return absl::OkStatus();
+    }
+    if (auto s = EmitTranscriptSegments(*text_or, next_segment_id++, start_ms,
+                                        end_ms, stream);
+        !s.ok()) {
+      return s;
+    }
+    return absl::OkStatus();
+  };
 
   while (stream->Read(&msg)) {
     if (msg.has_session_start()) {
@@ -138,6 +207,10 @@ Session::Run(::grpc::ServerReaderWriter<aegis::v1::EgressMessage,
     if (msg.has_pcm()) {
       if (state == State::Active) {
         AppendInt16LEAsFloat(msg.pcm().pcm(), &samples);
+        if (auto s = flush_window(/*force=*/false); !s.ok()) {
+          budget_->Release(reserve_bytes);
+          return s;
+        }
       }
       // In Paused state we deliberately drop PCM per ADR-0006.
       continue;
@@ -159,6 +232,10 @@ Session::Run(::grpc::ServerReaderWriter<aegis::v1::EgressMessage,
             payload.size()));
         if (pcm_or.ok()) {
           samples.insert(samples.end(), pcm_or->begin(), pcm_or->end());
+          if (auto s = flush_window(/*force=*/false); !s.ok()) {
+            budget_->Release(reserve_bytes);
+            return s;
+          }
         }
         // On decode error: log-and-drop per ADR-0016. A single
         // corrupt 20 ms frame should not tear down a session.
@@ -187,17 +264,11 @@ Session::Run(::grpc::ServerReaderWriter<aegis::v1::EgressMessage,
         "Session: IngestMessage with unknown payload");
   }
 
-  // Stage 5 — flush: transcribe accumulated PCM and emit segments.
-  if (!samples.empty()) {
-    auto text_or = engine->Transcribe(samples);
-    if (!text_or.ok()) {
-      budget_->Release(reserve_bytes);
-      return text_or.status();
-    }
-    if (auto s = EmitTranscriptSegments(*text_or, stream); !s.ok()) {
-      budget_->Release(reserve_bytes);
-      return s;
-    }
+  // Stage 5 — final flush for the trailing sub-window that never hit
+  // the live-window threshold. Ensures no audio is lost on EndMeeting.
+  if (auto s = flush_window(/*force=*/true); !s.ok()) {
+    budget_->Release(reserve_bytes);
+    return s;
   }
 
   budget_->Release(reserve_bytes);

--- a/engine_cpp/tests/integration/BUILD.bazel
+++ b/engine_cpp/tests/integration/BUILD.bazel
@@ -25,7 +25,12 @@ cc_test(
 cc_test(
     name = "stream_transcribe_test",
     srcs = ["stream_transcribe_test.cc"],
-    size = "medium",
+    # `large` — `medium` caps at 60 s, but this target now runs three
+    # cases each doing a full whisper model load (~2 s) + JFK transcribe
+    # (~5 s). Two transcribing cases × ~8 s each + overhead easily
+    # exceeds 60 s. Bumped 2026-04-20 when the LiveWindowEmitsMidStream
+    # case was added for Incident 14 regression coverage.
+    size = "large",
     data = [
         "@whisper_cpp//:samples",
     ],

--- a/engine_cpp/tests/integration/bge_m3_embed_test.cc
+++ b/engine_cpp/tests/integration/bge_m3_embed_test.cc
@@ -40,21 +40,26 @@ constexpr int kBgeM3Dims = 1024;
 
 bool FileExists(const std::string &path) { return std::ifstream(path).good(); }
 
-// Resolve the model path. Priority mirrors whisper_transcribe_test:
-//   1. AEGIS_MODEL_DIR env (explicit override — useful for CI caches).
-//   2. Bazel runfiles — if runfiles ever ships the model, pull it.
-//   3. <REPO_ROOT>/models/bge-m3-Q4_K_M.gguf (developer workflow).
+// Resolve the model path. Tries the ADR-0026 CAS layout first, then
+// falls back to legacy flat layout. The CAS path became the canonical
+// on-disk location 2026-04-20.
 std::string ResolveModelPath() {
+  constexpr const char *kCasRel =
+      "/bge-m3-q4km/"
+      "e251234fcb7d050991a6be491952f485bf5c641dd10c3272dc1301fd281ad50f.gguf";
+  constexpr const char *kLegacyRel = "/bge-m3-Q4_K_M.gguf";
+  std::string dir;
   if (const char *env = std::getenv("AEGIS_MODEL_DIR"); env != nullptr) {
-    return std::string(env) + "/bge-m3-Q4_K_M.gguf";
+    dir = env;
+  } else if (const char *env = std::getenv("TEST_SRCDIR"); env != nullptr) {
+    dir = std::string(env) + "/../../../../models";
+  } else {
+    dir = "models";
   }
-  if (const char *env = std::getenv("TEST_SRCDIR"); env != nullptr) {
-    const std::string candidate =
-        std::string(env) + "/../../../../models/bge-m3-Q4_K_M.gguf";
-    if (FileExists(candidate))
-      return candidate;
+  if (FileExists(dir + kCasRel)) {
+    return dir + kCasRel;
   }
-  return "models/bge-m3-Q4_K_M.gguf";
+  return dir + kLegacyRel;
 }
 
 float CosSim(const std::vector<float> &a, const std::vector<float> &b) {

--- a/engine_cpp/tests/integration/stream_transcribe_test.cc
+++ b/engine_cpp/tests/integration/stream_transcribe_test.cc
@@ -21,9 +21,13 @@
 #include <cstring>
 #include <fstream>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
+
+#include <algorithm>
 
 #include "absl/strings/ascii.h"
 #include "engine_cpp/src/audio/wav_reader.h"
@@ -38,11 +42,25 @@ namespace {
 
 bool FileExists(const std::string &path) { return std::ifstream(path).good(); }
 
+// Resolve the whisper-tiny-en model path, honoring the CAS layout
+// (ADR-0026) that's been live since 2026-04-20. Tries CAS first, then
+// falls back to the legacy flat filename so developers with old local
+// layouts still skip cleanly instead of silently mis-resolving.
 std::string ResolveModelPath() {
+  constexpr const char *kCasRel =
+      "/whisper-tiny-en/"
+      "921e4cf8686fdd993dcd081a5da5b6c365bfde1162e72b08d75ac75289920b1f.bin";
+  constexpr const char *kLegacyRel = "/ggml-tiny.en.bin";
+  std::string dir;
   if (const char *env = std::getenv("AEGIS_MODEL_DIR"); env != nullptr) {
-    return std::string(env) + "/ggml-tiny.en.bin";
+    dir = env;
+  } else {
+    dir = "models";
   }
-  return "models/ggml-tiny.en.bin";
+  if (FileExists(dir + kCasRel)) {
+    return dir + kCasRel;
+  }
+  return dir + kLegacyRel;
 }
 
 std::string ResolveWavPath() {
@@ -76,6 +94,41 @@ std::string FloatsToInt16LE(const std::vector<float> &samples) {
   return out;
 }
 
+// Helper — collected egress messages, accumulated text, captured
+// segment metadata. Populated by a background reader thread so the
+// client's writes and the server's writes can interleave. Pre–live-
+// windowing, the server wrote zero egress until WritesDone; a single-
+// threaded test that wrote all PCM first and read all egress after was
+// safe. With live windowing the server writes mid-stream — if the
+// client didn't start reading, the in-process gRPC channel's bounded
+// buffers filled and both sides deadlocked indefinitely. A background
+// reader is the minimal correct pattern for any bidi stream test that
+// crosses the "server writes during client writes" boundary.
+struct EgressCollection {
+  std::string all_text;
+  std::vector<std::uint64_t> segment_ids;
+  std::vector<std::int64_t> segment_spans_ms;
+  std::mutex mu;
+};
+
+std::thread
+SpawnEgressReader(::grpc::ClientReaderWriter<aegis::v1::IngestMessage,
+                                             aegis::v1::EgressMessage> *stream,
+                  EgressCollection *out) {
+  return std::thread([stream, out]() {
+    aegis::v1::EgressMessage egress;
+    while (stream->Read(&egress)) {
+      if (!egress.has_transcript())
+        continue;
+      const auto &t = egress.transcript();
+      std::lock_guard<std::mutex> lock(out->mu);
+      out->all_text += t.text();
+      out->segment_ids.push_back(t.segment_id());
+      out->segment_spans_ms.push_back(t.end_ms() - t.start_ms());
+    }
+  });
+}
+
 TEST(StreamTranscribeTest, JfkEndToEnd) {
   const std::string model_path = ResolveModelPath();
   if (!FileExists(model_path)) {
@@ -102,6 +155,10 @@ TEST(StreamTranscribeTest, JfkEndToEnd) {
   ::grpc::ClientContext ctx;
   auto stream = stub->StreamTranscribe(&ctx);
 
+  // Kick off background reader BEFORE writing — see EgressCollection doc.
+  EgressCollection collected;
+  std::thread reader = SpawnEgressReader(stream.get(), &collected);
+
   // Send SessionStart first.
   {
     aegis::v1::IngestMessage msg;
@@ -125,7 +182,7 @@ TEST(StreamTranscribeTest, JfkEndToEnd) {
 
   // Split into ~32 KB chunks to exercise the stream (not just one big write).
   constexpr std::size_t kChunkBytes = 32 * 1024;
-  uint64_t chunk_id = 0;
+  std::uint64_t chunk_id = 0;
   for (std::size_t off = 0; off < int16_le.size(); off += kChunkBytes) {
     const std::size_t n = std::min(kChunkBytes, int16_le.size() - off);
     aegis::v1::IngestMessage msg;
@@ -144,27 +201,157 @@ TEST(StreamTranscribeTest, JfkEndToEnd) {
   }
   stream->WritesDone();
 
-  // Collect all transcript segments emitted.
-  std::string all_text;
-  aegis::v1::EgressMessage egress;
-  while (stream->Read(&egress)) {
-    if (egress.has_transcript()) {
-      all_text += egress.transcript().text();
-    }
-  }
+  reader.join(); // Drains until server closes Read loop.
   const ::grpc::Status status = stream->Finish();
   EXPECT_TRUE(status.ok()) << "grpc status: " << status.error_message();
 
   // Budget must be fully released after session end.
   EXPECT_EQ(budget.BytesUsed(), 0u);
 
-  // Content check — JFK's opening line, lowercased for tokenizer robustness.
-  const std::string lower = absl::AsciiStrToLower(all_text);
-  EXPECT_NE(lower.find("ask not"), std::string::npos)
-      << "transcript did not contain 'ask not'; got: " << all_text;
-  EXPECT_NE(lower.find("your country"), std::string::npos)
-      << "transcript did not contain 'your country'; got: " << all_text;
+  // Content check — JFK's opening line, lowercased for tokenizer
+  // robustness. With live windowing the text is concatenated across
+  // per-window transcriptions; word boundaries may end up glued
+  // ("askNot"). We lowercase AND strip spaces before substring search
+  // so the assertion is robust to cut-at-boundary glue.
+  auto lowerNoSpace = [](std::string s) {
+    s = absl::AsciiStrToLower(s);
+    s.erase(std::remove(s.begin(), s.end(), ' '), s.end());
+    return s;
+  };
+  const std::string needle_1 = lowerNoSpace("ask not");
+  const std::string needle_2 = lowerNoSpace("your country");
+  const std::string hay = lowerNoSpace(collected.all_text);
+  EXPECT_NE(hay.find(needle_1), std::string::npos)
+      << "transcript did not contain 'ask not'; got: " << collected.all_text;
+  EXPECT_NE(hay.find(needle_2), std::string::npos)
+      << "transcript did not contain 'your country'; got: "
+      << collected.all_text;
 
+  server->Shutdown();
+}
+
+TEST(StreamTranscribeTest, LiveWindowEmitsMidStream) {
+  // Regression for Incident 14 (2026-04-20). Pre-fix `Session::Run`
+  // accumulated PCM for the entire stream and emitted a single
+  // transcript segment on final flush (Stage 5). A live listener saw
+  // nothing for the whole session — the "Live transcript" UI panel
+  // stayed at "Waiting for the first segment…" forever.
+  //
+  // This test asserts the live-windowing contract post-fix:
+  //   - Audio longer than one window (3 s) MUST produce at least one
+  //     transcript segment BEFORE the stream closes.
+  //   - Subsequent windows MUST emit additional segments — total
+  //     segments > 1 for a multi-window session (not a single batch).
+  //   - segment_id is a monotonic session-local counter starting at 1.
+  //   - start_ms < end_ms for every segment (timestamps are derived
+  //     from sample offsets, not hardcoded 0).
+  //
+  // Uses the background-reader pattern (see SpawnEgressReader) —
+  // under live windowing the server writes egress during the client's
+  // PCM-write phase, so a single-threaded client deadlocks on the
+  // in-process channel's bounded buffers.
+  //
+  // Gated on model presence (like JfkEndToEnd above) so CI without
+  // the 75 MB model stays green.
+  const std::string model_path = ResolveModelPath();
+  if (!FileExists(model_path)) {
+    GTEST_SKIP() << "model not present at " << model_path
+                 << ". Run ./tools/scripts/download_models.sh --all";
+  }
+  const std::string wav_path = ResolveWavPath();
+  if (!FileExists(wav_path)) {
+    GTEST_SKIP() << "audio fixture not present at " << wav_path;
+  }
+
+  auto samples_or = audio::ReadWav16kMono(wav_path);
+  ASSERT_TRUE(samples_or.ok()) << samples_or.status();
+  const std::vector<float> &samples = *samples_or;
+  // Require enough audio to span at least two 3-second windows.
+  ASSERT_GE(samples.size(), static_cast<std::size_t>(6 * 16000))
+      << "fixture too short for multi-window regression; need ≥6s, got "
+      << (samples.size() / 16000) << "s";
+  const std::string int16_le = FloatsToInt16LE(samples);
+
+  session::SessionBudget budget(1024ULL * 1024 * 1024);
+  AegisEngineServiceImpl service(&budget, model_path);
+
+  ::grpc::ServerBuilder builder;
+  builder.RegisterService(&service);
+  std::unique_ptr<::grpc::Server> server(builder.BuildAndStart());
+  ASSERT_TRUE(server);
+
+  auto channel = server->InProcessChannel(::grpc::ChannelArguments());
+  auto stub = aegis::v1::Engine::NewStub(channel);
+
+  ::grpc::ClientContext ctx;
+  auto stream = stub->StreamTranscribe(&ctx);
+
+  EgressCollection collected;
+  std::thread reader = SpawnEgressReader(stream.get(), &collected);
+
+  {
+    aegis::v1::IngestMessage msg;
+    auto *start = msg.mutable_session_start();
+    start->set_session_id("test-live-window");
+    auto *fmt = start->mutable_audio_format();
+    fmt->set_sample_rate_hz(16000);
+    fmt->set_channels(1);
+    fmt->set_bits_per_sample(16);
+    ASSERT_TRUE(stream->Write(msg));
+  }
+
+  // Chunk strategy: split PCM into ~32 KB PcmChunks (same as
+  // JfkEndToEnd). With 6+ seconds of audio at 32 KB per chunk
+  // (= 16384 samples = ~1.02 s), we feed at least 6 chunks —
+  // which triggers at least 2 window flushes at 3-second boundaries.
+  constexpr std::size_t kChunkBytes = 32 * 1024;
+  std::uint64_t chunk_id = 0;
+  for (std::size_t off = 0; off < int16_le.size(); off += kChunkBytes) {
+    const std::size_t n = std::min(kChunkBytes, int16_le.size() - off);
+    aegis::v1::IngestMessage msg;
+    auto *pcm = msg.mutable_pcm();
+    pcm->set_pcm(int16_le.data() + off, n);
+    pcm->set_chunk_id(chunk_id++);
+    pcm->set_offset_ms(0);
+    ASSERT_TRUE(stream->Write(msg));
+  }
+
+  {
+    aegis::v1::IngestMessage msg;
+    msg.mutable_control()->set_kind(aegis::v1::CONTROL_KIND_END_STREAM);
+    ASSERT_TRUE(stream->Write(msg));
+  }
+  stream->WritesDone();
+  reader.join();
+
+  const ::grpc::Status status = stream->Finish();
+  EXPECT_TRUE(status.ok()) << "grpc status: " << status.error_message();
+
+  // Core regression assertions for Incident 14:
+  std::lock_guard<std::mutex> lock(collected.mu);
+
+  // 1) Multiple segments — batch-mode would have produced exactly 1.
+  EXPECT_GT(collected.segment_ids.size(), 1u)
+      << "live windowing regressed: only " << collected.segment_ids.size()
+      << " segment(s) emitted; pre-fix Session::Run emitted exactly 1 at "
+         "stream end. A working live windowing pipeline emits multiple "
+         "segments over a >6s audio stream.";
+
+  // 2) segment_id is monotonic starting from 1.
+  for (std::size_t i = 0; i < collected.segment_ids.size(); ++i) {
+    EXPECT_EQ(collected.segment_ids[i], static_cast<std::uint64_t>(i + 1))
+        << "segment_id not monotonic at index " << i;
+  }
+
+  // 3) Each segment carries a non-trivial time span (start_ms < end_ms).
+  for (std::size_t i = 0; i < collected.segment_spans_ms.size(); ++i) {
+    EXPECT_GT(collected.segment_spans_ms[i], 0)
+        << "segment " << (i + 1)
+        << " has zero/negative time span — start_ms "
+           "and end_ms must be derived from sample offsets, not hardcoded 0";
+  }
+
+  EXPECT_EQ(budget.BytesUsed(), 0u);
   server->Shutdown();
 }
 

--- a/engine_cpp/tests/integration/whisper_transcribe_test.cc
+++ b/engine_cpp/tests/integration/whisper_transcribe_test.cc
@@ -34,21 +34,27 @@ bool FileExists(const std::string &path) { return std::ifstream(path).good(); }
 // Resolve the model path. Priority:
 //   1. AEGIS_MODEL_DIR env (explicit override — useful for CI caches)
 //   2. Bazel runfiles — if runfiles ever ships the model, pull it.
-//   3. <REPO_ROOT>/models/ggml-tiny.en.bin (developer workflow).
+//   3. <REPO_ROOT>/models — local developer workflow.
+// Tries the ADR-0026 CAS layout first (canonical since 2026-04-20),
+// then falls back to the legacy flat filename for stale local setups.
 std::string ResolveModelPath() {
+  constexpr const char *kCasRel =
+      "/whisper-tiny-en/"
+      "921e4cf8686fdd993dcd081a5da5b6c365bfde1162e72b08d75ac75289920b1f.bin";
+  constexpr const char *kLegacyRel = "/ggml-tiny.en.bin";
+  std::string dir;
   if (const char *env = std::getenv("AEGIS_MODEL_DIR"); env != nullptr) {
-    return std::string(env) + "/ggml-tiny.en.bin";
+    dir = env;
+  } else if (const char *env = std::getenv("TEST_SRCDIR"); env != nullptr) {
+    // Bazel runfiles root — walk up to the repo's models/ sibling.
+    dir = std::string(env) + "/../../../../models";
+  } else {
+    dir = "models";
   }
-  if (const char *env = std::getenv("TEST_SRCDIR"); env != nullptr) {
-    // Bazel runfiles root — tests execute here when invoked via `bazel test`.
-    // Walk up to find a models/ sibling.
-    const std::string candidate =
-        std::string(env) + "/../../../../models/ggml-tiny.en.bin";
-    if (FileExists(candidate))
-      return candidate;
+  if (FileExists(dir + kCasRel)) {
+    return dir + kCasRel;
   }
-  // Fallback for developers running the test binary directly.
-  return "models/ggml-tiny.en.bin";
+  return dir + kLegacyRel;
 }
 
 std::string ResolveWavPath() {

--- a/frontend_web/package.json
+++ b/frontend_web/package.json
@@ -14,6 +14,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "e2e": "playwright test",
     "e2e:install": "playwright install --with-deps chromium webkit"
   },
@@ -33,7 +35,9 @@
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.3.4",
+    "happy-dom": "^20.9.0",
     "typescript": "^5.7.2",
-    "vite": "^6.0.7"
+    "vite": "^6.0.7",
+    "vitest": "^4.1.4"
   }
 }

--- a/frontend_web/src/providers/TranscriptStreamProvider/WebSocketTranscriptStreamProvider.test.ts
+++ b/frontend_web/src/providers/TranscriptStreamProvider/WebSocketTranscriptStreamProvider.test.ts
@@ -1,0 +1,315 @@
+// frontend_web/src/providers/TranscriptStreamProvider/WebSocketTranscriptStreamProvider.test.ts
+//
+// Regression tests for Incident 14 (2026-04-20). The original
+// `WebSocketTranscriptStreamProvider` carried a Phase-1 stub that only
+// handled string WebSocket frames and silently dropped binary frames.
+// The Go Gateway sends `aegis.v1.ViewerEvent` as binary protobuf via
+// `websocket.MessageBinary`, so in LAN mode the host UI received
+// perfectly-flowing transcripts from the gateway but rendered nothing.
+//
+// These tests assert the contract that a refreshed decoder must hold:
+//
+//  1. Binary frames encoding a real ViewerEvent are parsed and
+//     forwarded through `onEvent` with the correct shape.
+//  2. Unknown / empty payload oneofs surface as no-event (not as
+//     a crash).
+//  3. Malformed binary triggers `onError` rather than silent drop.
+//  4. Stray string frames are surfaced via `onError` (they indicate
+//     a gateway protocol bug; must not be silently consumed).
+//  5. `unsubscribe()` is idempotent and closes the socket.
+//
+// The test substitutes a `FakeWebSocket` for the real `WebSocket`
+// global — Vitest provides no built-in WS mock, and the alternative
+// (intercepting via `vi.stubGlobal`) achieves the same result with
+// more boilerplate. The fake fires lifecycle events in the order a
+// real browser socket would.
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+
+import {
+  HintUrgency as ProtoHintUrgency,
+  MeetingState as ProtoMeetingState,
+  MeetingStateChange,
+  PrompterHint,
+  TranscriptSegment,
+  ViewerEvent as ProtoViewerEvent,
+} from "@/gen/proto/aegis/v1/aegis_pb";
+
+import { WebSocketTranscriptStreamProvider } from "./WebSocketTranscriptStreamProvider";
+import type { ViewerEvent } from "./types";
+
+// ---- Test double: enough of the WebSocket surface for this provider ----
+
+interface FakeWebSocketInstance {
+  readonly url: string;
+  binaryType: BinaryType;
+  onmessage: ((ev: MessageEvent) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  onclose: ((ev: CloseEvent) => void) | null;
+  readyState: number;
+  close(code?: number, reason?: string): void;
+  // Test-only helpers — not on the real WebSocket interface.
+  _emitBinary(buf: ArrayBuffer): void;
+  _emitString(s: string): void;
+  _emitError(): void;
+  _emitClose(code: number, reason: string): void;
+}
+
+let lastSocket: FakeWebSocketInstance | null = null;
+
+class FakeWebSocket implements FakeWebSocketInstance {
+  public binaryType: BinaryType = "blob";
+  public onmessage: ((ev: MessageEvent) => void) | null = null;
+  public onerror: ((ev: Event) => void) | null = null;
+  public onclose: ((ev: CloseEvent) => void) | null = null;
+  public readyState = 1; // OPEN
+  constructor(public readonly url: string) {
+    lastSocket = this;
+  }
+  close(code = 1000, reason = ""): void {
+    this.readyState = 3; // CLOSED
+    if (this.onclose) {
+      this.onclose(new CloseEvent("close", { code, reason }));
+    }
+  }
+  _emitBinary(buf: ArrayBuffer): void {
+    if (!this.onmessage) return;
+    this.onmessage(new MessageEvent("message", { data: buf }));
+  }
+  _emitString(s: string): void {
+    if (!this.onmessage) return;
+    this.onmessage(new MessageEvent("message", { data: s }));
+  }
+  _emitError(): void {
+    if (this.onerror) {
+      this.onerror(new Event("error"));
+    }
+  }
+  _emitClose(code: number, reason: string): void {
+    if (this.onclose) {
+      this.onclose(new CloseEvent("close", { code, reason }));
+    }
+  }
+}
+
+// Stash and swap the real WebSocket during each test.
+const realWebSocket = globalThis.WebSocket;
+
+beforeEach(() => {
+  lastSocket = null;
+  (globalThis as { WebSocket: typeof WebSocket }).WebSocket =
+    FakeWebSocket as unknown as typeof WebSocket;
+});
+
+afterEach(() => {
+  (globalThis as { WebSocket: typeof WebSocket }).WebSocket = realWebSocket;
+});
+
+// ---- Helpers ----
+
+function encodeViewerEvent(build: (ve: ProtoViewerEvent) => void): ArrayBuffer {
+  const ve = new ProtoViewerEvent();
+  build(ve);
+  const bytes = ve.toBinary();
+  // The provider expects an ArrayBuffer; WebSocket frames with
+  // `binaryType = "arraybuffer"` arrive as such. Make sure the
+  // underlying buffer is exactly the right size (toBinary() returns
+  // a Uint8Array that can share a larger backing buffer via pool
+  // allocators).
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  );
+}
+
+function newProvider(): WebSocketTranscriptStreamProvider {
+  return new WebSocketTranscriptStreamProvider({
+    endpoint: "http://localhost:8080",
+  });
+}
+
+const REQUEST = { sessionId: "test-session-42", viewerToken: "tok" };
+
+// ---- Tests ----
+
+describe("WebSocketTranscriptStreamProvider — binary frame decoding (Incident 14 regression)", () => {
+  test("transcript binary frame → onEvent with kind=transcript and correct fields", () => {
+    const events: ViewerEvent[] = [];
+    const provider = newProvider();
+    provider.subscribe(REQUEST, { onEvent: (ev) => events.push(ev) });
+
+    const frame = encodeViewerEvent((ve) => {
+      ve.sequence = 7n;
+      const t = new TranscriptSegment();
+      t.segmentId = 3n;
+      t.speakerLabel = "Speaker_0";
+      t.text = "ask not what your country can do for you";
+      t.isFinal = true;
+      t.isQuestion = false;
+      ve.payload = { case: "transcript", value: t };
+    });
+    lastSocket!._emitBinary(frame);
+
+    expect(events).toHaveLength(1);
+    const got = events[0];
+    expect(got.kind).toBe("transcript");
+    if (got.kind === "transcript") {
+      expect(got.sequence).toBe(7);
+      expect(got.segmentId).toBe(3);
+      expect(got.speakerLabel).toBe("Speaker_0");
+      expect(got.text).toBe("ask not what your country can do for you");
+      expect(got.isFinal).toBe(true);
+      expect(got.isQuestion).toBe(false);
+    }
+  });
+
+  test("hint binary frame → onEvent with kind=hint and mapped urgency", () => {
+    const events: ViewerEvent[] = [];
+    const provider = newProvider();
+    provider.subscribe(REQUEST, { onEvent: (ev) => events.push(ev) });
+
+    const frame = encodeViewerEvent((ve) => {
+      const h = new PrompterHint();
+      h.hintId = 12n;
+      h.suggestion = "Taiwan's population is ~23 million.";
+      h.urgency = ProtoHintUrgency.HIGH;
+      ve.payload = { case: "hint", value: h };
+    });
+    lastSocket!._emitBinary(frame);
+
+    expect(events).toHaveLength(1);
+    const got = events[0];
+    expect(got.kind).toBe("hint");
+    if (got.kind === "hint") {
+      expect(got.urgency).toBe("high");
+      expect(got.suggestion).toMatch(/Taiwan/);
+    }
+  });
+
+  test("state change binary frame → onEvent with kind=state", () => {
+    const events: ViewerEvent[] = [];
+    const provider = newProvider();
+    provider.subscribe(REQUEST, { onEvent: (ev) => events.push(ev) });
+
+    const frame = encodeViewerEvent((ve) => {
+      const s = new MeetingStateChange();
+      s.state = ProtoMeetingState.ACTIVE;
+      s.reason = "joined";
+      ve.payload = { case: "stateChange", value: s };
+    });
+    lastSocket!._emitBinary(frame);
+
+    expect(events).toHaveLength(1);
+    const got = events[0];
+    expect(got.kind).toBe("state");
+    if (got.kind === "state") {
+      expect(got.state).toBe("active");
+      expect(got.reason).toBe("joined");
+    }
+  });
+
+  test("empty-payload frame → no onEvent (not a crash)", () => {
+    const events: ViewerEvent[] = [];
+    const errors: Error[] = [];
+    const provider = newProvider();
+    provider.subscribe(REQUEST, {
+      onEvent: (ev) => events.push(ev),
+      onError: (e) => errors.push(e),
+    });
+
+    // ViewerEvent with payload.case === undefined
+    const frame = encodeViewerEvent(() => {
+      /* leave payload unset */
+    });
+    lastSocket!._emitBinary(frame);
+
+    expect(events).toHaveLength(0);
+    expect(errors).toHaveLength(0);
+  });
+
+  test("malformed binary → onError (not silent drop — this was the Incident 14 shape)", () => {
+    const events: ViewerEvent[] = [];
+    const errors: Error[] = [];
+    const provider = newProvider();
+    provider.subscribe(REQUEST, {
+      onEvent: (ev) => events.push(ev),
+      onError: (e) => errors.push(e),
+    });
+
+    // Random bytes unlikely to parse as a well-formed ViewerEvent.
+    const bad = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+    lastSocket!._emitBinary(
+      bad.buffer.slice(bad.byteOffset, bad.byteOffset + bad.byteLength),
+    );
+
+    expect(events).toHaveLength(0);
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors[0].message).toMatch(/decode/i);
+  });
+
+  test("string frame → onError (gateway contract violation must be surfaced, not dropped — direct Incident 14 regression)", () => {
+    const events: ViewerEvent[] = [];
+    const errors: Error[] = [];
+    const provider = newProvider();
+    provider.subscribe(REQUEST, {
+      onEvent: (ev) => events.push(ev),
+      onError: (e) => errors.push(e),
+    });
+
+    lastSocket!._emitString("hello text frame");
+
+    expect(events).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(/text frame/);
+  });
+
+  test("unsubscribe() closes socket and is idempotent", () => {
+    const provider = newProvider();
+    const sub = provider.subscribe(REQUEST, { onEvent: () => undefined });
+
+    expect(lastSocket!.readyState).toBe(1);
+    sub.unsubscribe();
+    expect(lastSocket!.readyState).toBe(3);
+    // Second call must not throw.
+    sub.unsubscribe();
+    expect(lastSocket!.readyState).toBe(3);
+  });
+
+  test("ws.onclose forwarded through onClose callback", () => {
+    let closeReason: string | undefined;
+    const provider = newProvider();
+    provider.subscribe(REQUEST, {
+      onEvent: () => undefined,
+      onClose: (reason) => {
+        closeReason = reason;
+      },
+    });
+
+    lastSocket!._emitClose(1006, "abnormal");
+
+    expect(closeReason).toMatch(/code=1006/);
+    expect(closeReason).toMatch(/abnormal/);
+  });
+
+  test("sets binaryType=arraybuffer so browser delivers ArrayBuffer (not Blob) — precondition for the decoder", () => {
+    const provider = newProvider();
+    provider.subscribe(REQUEST, { onEvent: () => undefined });
+    expect(lastSocket!.binaryType).toBe("arraybuffer");
+  });
+
+  test("builds the WS URL with http→ws scheme swap and url-encoded token", () => {
+    const provider = newProvider();
+    provider.subscribe(
+      { sessionId: "abc", viewerToken: "t&k=x?y" },
+      { onEvent: () => undefined },
+    );
+    // http:// → ws://
+    expect(lastSocket!.url.startsWith("ws://")).toBe(true);
+    // `&`, `=`, `?` in the token are encoded.
+    expect(lastSocket!.url).toContain("token=t%26k%3Dx%3Fy");
+    expect(lastSocket!.url).toContain("session_id=abc");
+    expect(
+      lastSocket!.url.endsWith("/ws/viewer?session_id=abc&token=t%26k%3Dx%3Fy"),
+    ).toBe(true);
+  });
+});

--- a/frontend_web/src/providers/TranscriptStreamProvider/WebSocketTranscriptStreamProvider.ts
+++ b/frontend_web/src/providers/TranscriptStreamProvider/WebSocketTranscriptStreamProvider.ts
@@ -8,17 +8,30 @@
 // allowed from insecure contexts on all major browsers, so Local
 // mode uses WebSocket + Protobuf binary framing.
 //
-// Phase 1 C3 ships the transport wrapper; Phase 2 adds real
-// protobuf-ts decoding of ViewerEvent frames once the Gateway
-// side exists.
+// Wire format: each ws.send is a single binary frame carrying one
+// `aegis.v1.ViewerEvent` marshalled via proto3. The Go Gateway
+// side (`gateway_go/internal/ws/ws.go` `sendEvent`) does the mirror
+// encode. Earlier this file was a Phase-1 stub that only handled
+// string frames and dropped binary — the bug surfaced as "transcript
+// segments emit on engine, broadcast delivers to WS subscriber, but
+// host UI shows nothing". See docs/incidents.md for context.
+
+import {
+  HintUrgency as ProtoHintUrgency,
+  MeetingState as ProtoMeetingState,
+  ViewerEvent as ProtoViewerEvent,
+} from "@/gen/proto/aegis/v1/aegis_pb";
 
 import type {
+  HintUrgency,
   JoinRequest,
+  MeetingState,
   OnClose,
   OnError,
   OnEvent,
   Subscription,
   TranscriptStreamProvider,
+  ViewerEvent,
 } from "./types";
 
 export interface WebSocketConfig {
@@ -36,6 +49,105 @@ function buildWebSocketUrl(cfg: WebSocketConfig, req: JoinRequest): string {
   const sid = encodeURIComponent(req.sessionId);
   const token = encodeURIComponent(req.viewerToken);
   return `${base}/ws/viewer?session_id=${sid}&token=${token}`;
+}
+
+// bigintToNumberSafely — protoInt64 fields (sequence, segment_id, etc.)
+// arrive as bigint. The UI never reasons about values above 2^53, so the
+// narrow cast is safe for expected cardinality; if a value somehow
+// overflows we clamp to Number.MAX_SAFE_INTEGER rather than returning NaN
+// or throwing — a degraded but still-rendered segment is the correct
+// outcome for a local-mode viewer.
+function bigintToNumber(v: bigint): number {
+  if (v > BigInt(Number.MAX_SAFE_INTEGER)) return Number.MAX_SAFE_INTEGER;
+  return Number(v);
+}
+
+function timestampToMs(
+  ts: { seconds: bigint; nanos: number } | undefined,
+): number {
+  if (!ts) return Date.now();
+  return bigintToNumber(ts.seconds) * 1000 + Math.floor(ts.nanos / 1e6);
+}
+
+function mapMeetingState(s: ProtoMeetingState): MeetingState {
+  switch (s) {
+    case ProtoMeetingState.ACTIVE:
+      return "active";
+    case ProtoMeetingState.HOST_RECONNECTING:
+      return "host-reconnecting";
+    case ProtoMeetingState.ENDED:
+      return "ended";
+    case ProtoMeetingState.ENGINE_BUSY:
+      return "engine-busy";
+    default:
+      return "active";
+  }
+}
+
+function mapHintUrgency(u: ProtoHintUrgency): HintUrgency {
+  switch (u) {
+    case ProtoHintUrgency.LOW:
+      return "low";
+    case ProtoHintUrgency.HIGH:
+      return "high";
+    case ProtoHintUrgency.URGENT:
+      return "urgent";
+    default:
+      return "normal";
+  }
+}
+
+// decodeBinaryFrame — parse a single gateway-emitted binary WebSocket
+// frame into the local ViewerEvent shape the UI consumes. Returns null
+// if the proto payload oneof is unset (indicates a malformed frame
+// or a future variant we don't know how to render yet).
+function decodeBinaryFrame(buf: ArrayBuffer): ViewerEvent | null {
+  const proto = ProtoViewerEvent.fromBinary(new Uint8Array(buf));
+  const emittedAtMs = timestampToMs(proto.emittedAt);
+  const sequence = bigintToNumber(proto.sequence);
+
+  switch (proto.payload.case) {
+    case "transcript": {
+      const t = proto.payload.value;
+      return {
+        kind: "transcript",
+        sequence,
+        emittedAtMs,
+        segmentId: bigintToNumber(t.segmentId),
+        speakerLabel: t.speakerLabel,
+        text: t.text,
+        isFinal: t.isFinal,
+        isQuestion: t.isQuestion,
+      };
+    }
+    case "hint": {
+      const h = proto.payload.value;
+      // Conditional spread for optional fields — types.ts declares
+      // `rationale?: string` with `exactOptionalPropertyTypes: true`,
+      // which forbids assigning `undefined` explicitly.
+      return {
+        kind: "hint",
+        sequence,
+        emittedAtMs,
+        hintId: bigintToNumber(h.hintId),
+        suggestion: h.suggestion,
+        urgency: mapHintUrgency(h.urgency),
+        ...(h.rationale ? { rationale: h.rationale } : {}),
+      };
+    }
+    case "stateChange": {
+      const s = proto.payload.value;
+      return {
+        kind: "state",
+        sequence,
+        emittedAtMs,
+        state: mapMeetingState(s.state),
+        ...(s.reason ? { reason: s.reason } : {}),
+      };
+    }
+    default:
+      return null;
+  }
 }
 
 export class WebSocketTranscriptStreamProvider
@@ -62,18 +174,38 @@ export class WebSocketTranscriptStreamProvider
     ws.binaryType = "arraybuffer";
 
     ws.onmessage = (ev: MessageEvent): void => {
-      // Phase 2: decode ev.data as a binary-wire aegis.v1.ViewerEvent
-      // via protobuf-ts and forward to onEvent. For now, emit a
-      // synthetic event proving the WS connected.
+      if (ev.data instanceof ArrayBuffer) {
+        let event: ViewerEvent | null = null;
+        try {
+          event = decodeBinaryFrame(ev.data);
+        } catch (err) {
+          callbacks.onError?.(
+            new Error(
+              `failed to decode ViewerEvent binary frame: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            ),
+          );
+          return;
+        }
+        if (event !== null) {
+          callbacks.onEvent(event);
+        }
+        return;
+      }
       if (typeof ev.data === "string") {
-        // Some test servers echo plain text; accept + log.
-        callbacks.onEvent({
-          kind: "state",
-          sequence: 0,
-          emittedAtMs: Date.now(),
-          state: "active",
-          reason: `received text frame (${ev.data.length} chars); Phase 2 decodes real protobuf`,
-        });
+        // Gateway never emits text frames; if one arrives it is either
+        // a test double or a protocol bug. Treat as non-fatal — log via
+        // onError so the caller (HostPage / ViewerPage) can surface it
+        // in the console without tearing the subscription down.
+        callbacks.onError?.(
+          new Error(
+            `unexpected text frame on Local-mode WS (expected binary ViewerEvent): ${ev.data.slice(
+              0,
+              80,
+            )}`,
+          ),
+        );
       }
     };
 

--- a/frontend_web/vite.config.ts
+++ b/frontend_web/vite.config.ts
@@ -5,7 +5,14 @@
 // in Local mode. No special proxying here — the client talks to the
 // gateway at a runtime-configured URL (env-var at build time for now;
 // ADR-0002 Constraint 2 provider abstractions handle transport swap).
+//
+// Vitest section below shares this config so unit tests resolve the
+// same `@/` path alias and plugin stack as `vite dev` / `vite build`.
+// Without the shared config, a `from "@/gen/…"` import in a test file
+// would fail with "cannot resolve" — typecheck would still pass (tsc
+// reads tsconfig paths) but the test runner wouldn't.
 
+/// <reference types="vitest" />
 import { fileURLToPath, URL } from "node:url";
 
 import { defineConfig } from "vite";
@@ -44,5 +51,15 @@ export default defineConfig({
     // boss-scans-QR-on-phone" flow per ADR-0007. Vite prints the
     // first non-loopback IPv4 under "Network:" when this is on.
     host: true,
+  },
+  test: {
+    // happy-dom is preferred over jsdom for Vitest: faster startup,
+    // smaller, and our unit tests don't need jsdom-only APIs (we touch
+    // `WebSocket`, `ArrayBuffer`, and plain DOM constants only).
+    environment: "happy-dom",
+    globals: false, // force explicit `import { test, expect } from "vitest"`
+    // Match Vitest defaults but scope to src/ so Playwright's e2e/
+    // folder (*.spec.ts) is not swept in here.
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
   },
 });

--- a/gateway_go/internal/pipeline/pipeline.go
+++ b/gateway_go/internal/pipeline/pipeline.go
@@ -46,7 +46,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -93,6 +95,15 @@ type Pipeline struct {
 
 	// closed guards the idempotence of Close.
 	closeOnce sync.Once
+
+	// Observability counters — edge-to-edge tracing per session_id.
+	// audioFramesForwarded counts non-empty Opus payloads WriteRTPPayload
+	// has successfully sent to the engine. egressMessagesReceived counts
+	// messages runEgress has Recv'd from the engine. Both are used for
+	// "first ever" Info-level log lines (no per-frame spam) + readable
+	// counters for /metrics exposure.
+	audioFramesForwarded atomic.Uint64
+	egressMessages       atomic.Uint64
 }
 
 // New opens a StreamTranscribe bidi stream to the engine, sends the
@@ -123,8 +134,11 @@ func New(
 
 	stream, err := engine.StreamTranscribe(ctx)
 	if err != nil {
+		slog.Warn("pipeline.engine.stream_open_failed",
+			"session_id", sessionID, "err", err.Error())
 		return nil, fmt.Errorf("pipeline: StreamTranscribe open: %w", err)
 	}
+	slog.Info("pipeline.engine.stream_opened", "session_id", sessionID)
 
 	start := &aegisv1.IngestMessage{
 		Payload: &aegisv1.IngestMessage_SessionStart{
@@ -142,10 +156,17 @@ func New(
 		},
 	}
 	if err := stream.Send(start); err != nil {
+		slog.Warn("pipeline.session_start_send_failed",
+			"session_id", sessionID, "err", err.Error())
 		// Best-effort close; the caller will see the error from Send.
 		_ = stream.CloseSend()
 		return nil, fmt.Errorf("pipeline: SessionStart: %w", err)
 	}
+	slog.Info("pipeline.session_start_sent",
+		"session_id", sessionID,
+		"tenant_id", sess.TenantID,
+		"rag_id", sess.RAGID,
+		"sample_rate_hz", sampleRateHz)
 
 	p := &Pipeline{
 		sess:      sess,
@@ -192,9 +213,29 @@ func (p *Pipeline) WriteRTPPayload(payload []byte) error {
 	defer p.sendMu.Unlock()
 	p.chunkSeq++
 	if err := p.stream.Send(msg); err != nil {
+		slog.Warn("pipeline.audio.send_failed",
+			"session_id", p.sessionID,
+			"chunk_id", p.chunkSeq,
+			"err", err.Error())
 		return fmt.Errorf("pipeline: send Opus: %w", err)
 	}
+	if n := p.audioFramesForwarded.Add(1); n == 1 {
+		slog.Info("pipeline.audio.first_frame_forwarded",
+			"session_id", p.sessionID,
+			"payload_bytes", len(payload))
+	}
 	return nil
+}
+
+// previewText truncates transcript text for safe inclusion in a log line
+// (avoids dumping an entire paragraph). 80-char cap is enough to read-at-
+// a-glance "who emitted what" while keeping log lines scannable.
+func previewText(s string) string {
+	const cap = 80
+	if len(s) <= cap {
+		return s
+	}
+	return s[:cap] + "…"
 }
 
 // WritePCM sends a PCM chunk (already 16 kHz mono 16-bit little-endian,
@@ -284,23 +325,42 @@ func (p *Pipeline) Close() {
 // Closing p.done on exit is the synchronization point Close waits on.
 func (p *Pipeline) runEgress() {
 	defer close(p.done)
+	defer slog.Info("pipeline.engine.egress_loop_exited",
+		"session_id", p.sessionID,
+		"messages_received", p.egressMessages.Load(),
+		"audio_frames_forwarded", p.audioFramesForwarded.Load())
 	for {
 		msg, err := p.stream.Recv()
 		if err != nil {
 			// io.EOF is the normal END_STREAM path; other errors
 			// (context cancellation, stream reset) are also terminal
 			// — in either case, no more broadcasts are possible.
+			// Historically this branch `return`ed silently on every
+			// non-EOF error, which swallowed transcribe-side failures
+			// whole. Now every stream close is logged with reason +
+			// session_id so ops can grep the full lifecycle.
 			if err == io.EOF {
+				slog.Info("pipeline.engine.stream_closed_eof",
+					"session_id", p.sessionID)
 				return
 			}
+			slog.Warn("pipeline.engine.stream_closed_err",
+				"session_id", p.sessionID,
+				"err", err.Error(),
+				"messages_received_before_err", p.egressMessages.Load())
 			return
+		}
+		if n := p.egressMessages.Add(1); n == 1 {
+			slog.Info("pipeline.engine.first_egress_message",
+				"session_id", p.sessionID,
+				"payload_type", fmt.Sprintf("%T", msg.GetPayload()))
 		}
 		switch payload := msg.GetPayload().(type) {
 		case *aegisv1.EgressMessage_Transcript:
 			if payload.Transcript == nil {
 				continue
 			}
-			p.sess.Broadcast(&aegisv1.ViewerEvent{
+			delivered, dropped := p.sess.Broadcast(&aegisv1.ViewerEvent{
 				// Sequence is set per-subscription by the viewer
 				// handler (JoinAsViewer / ws.Handler) — leaving it
 				// zero here avoids ambiguity.
@@ -309,16 +369,35 @@ func (p *Pipeline) runEgress() {
 					Transcript: payload.Transcript,
 				},
 			})
+			if delivered == 0 {
+				slog.Warn("pipeline.broadcast.transcript_no_subscribers",
+					"session_id", p.sessionID,
+					"segment_id", payload.Transcript.GetSegmentId(),
+					"text_preview", previewText(payload.Transcript.GetText()),
+					"dropped", dropped,
+					"note", "engine produced a transcript segment but no viewer / host subscription is connected; segment is lost (ADR-0004 stateless relay)")
+			} else {
+				slog.Debug("pipeline.broadcast.transcript",
+					"session_id", p.sessionID,
+					"segment_id", payload.Transcript.GetSegmentId(),
+					"delivered", delivered,
+					"dropped", dropped)
+			}
 		case *aegisv1.EgressMessage_Hint:
 			if payload.Hint == nil {
 				continue
 			}
-			p.sess.Broadcast(&aegisv1.ViewerEvent{
+			delivered, dropped := p.sess.Broadcast(&aegisv1.ViewerEvent{
 				EmittedAt: timestamppb.New(time.Now()),
 				Payload: &aegisv1.ViewerEvent_Hint{
 					Hint: payload.Hint,
 				},
 			})
+			if delivered == 0 {
+				slog.Warn("pipeline.broadcast.hint_no_subscribers",
+					"session_id", p.sessionID,
+					"dropped", dropped)
+			}
 		default:
 			// EgressMessage_Status and EgressMessage_Error are not yet
 			// fanned out to viewers; later phases may emit state

--- a/gateway_go/internal/webrtc/negotiator.go
+++ b/gateway_go/internal/webrtc/negotiator.go
@@ -22,6 +22,7 @@ package webrtc
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 
@@ -137,12 +138,29 @@ func (n *Negotiator) Negotiate(ctx context.Context, sessionID, offerSDP string) 
 	// Register OnTrack before SetRemoteDescription so we never miss a
 	// track that the remote side starts immediately on signaling.
 	pc.OnTrack(func(track *pwebrtc.TrackRemote, _ *pwebrtc.RTPReceiver) {
+		slog.Debug("webrtc.OnTrack fired",
+			"session_id", sessionID,
+			"codec", track.Codec().MimeType,
+			"ssrc", uint32(track.SSRC()),
+			"payload_type", uint8(track.PayloadType()),
+		)
 		for {
 			pkt, _, readErr := track.ReadRTP()
 			if readErr != nil {
+				slog.Debug("webrtc.OnTrack loop ended",
+					"session_id", sessionID,
+					"total_packets", cs.packets.Load(),
+					"err", readErr.Error(),
+				)
 				return // PeerConnection closed or track ended.
 			}
-			cs.packets.Add(1)
+			prev := cs.packets.Add(1)
+			if prev == 1 {
+				slog.Debug("webrtc.first RTP packet",
+					"session_id", sessionID,
+					"payload_bytes", len(pkt.Payload),
+				)
+			}
 			if len(pkt.Payload) == 0 {
 				continue
 			}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,12 +49,18 @@ importers:
       "@vitejs/plugin-react":
         specifier: ^4.3.4
         version: 4.3.4(vite@6.0.7)
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
       vite:
         specifier: ^6.0.7
         version: 6.0.7(@types/node@20.19.0)
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@20.19.0)(happy-dom@20.9.0)(vite@6.0.7)
 
 packages:
   /@babel/code-frame@7.29.0:
@@ -952,6 +958,13 @@ packages:
     dev: true
     optional: true
 
+  /@standard-schema/spec@1.1.0:
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
+    dev: true
+
   /@types/babel__core@7.20.5:
     resolution:
       {
@@ -993,12 +1006,29 @@ packages:
       "@babel/types": 7.29.0
     dev: true
 
+  /@types/chai@5.2.3:
+    resolution:
+      {
+        integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
+      }
+    dependencies:
+      "@types/deep-eql": 4.0.2
+      assertion-error: 2.0.1
+    dev: true
+
   /@types/cookie@0.6.0:
     resolution:
       {
         integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==,
       }
     dev: false
+
+  /@types/deep-eql@4.0.2:
+    resolution:
+      {
+        integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
+      }
+    dev: true
 
   /@types/estree@1.0.8:
     resolution:
@@ -1036,6 +1066,22 @@ packages:
       csstype: 3.2.3
     dev: true
 
+  /@types/whatwg-mimetype@3.0.2:
+    resolution:
+      {
+        integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==,
+      }
+    dev: true
+
+  /@types/ws@8.18.1:
+    resolution:
+      {
+        integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==,
+      }
+    dependencies:
+      "@types/node": 20.19.0
+    dev: true
+
   /@vitejs/plugin-react@4.3.4(vite@6.0.7):
     resolution:
       {
@@ -1053,6 +1099,97 @@ packages:
       vite: 6.0.7(@types/node@20.19.0)
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@vitest/expect@4.1.4:
+    resolution:
+      {
+        integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==,
+      }
+    dependencies:
+      "@standard-schema/spec": 1.1.0
+      "@types/chai": 5.2.3
+      "@vitest/spy": 4.1.4
+      "@vitest/utils": 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+    dev: true
+
+  /@vitest/mocker@4.1.4(vite@6.0.7):
+    resolution:
+      {
+        integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==,
+      }
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      "@vitest/spy": 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      vite: 6.0.7(@types/node@20.19.0)
+    dev: true
+
+  /@vitest/pretty-format@4.1.4:
+    resolution:
+      {
+        integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==,
+      }
+    dependencies:
+      tinyrainbow: 3.1.0
+    dev: true
+
+  /@vitest/runner@4.1.4:
+    resolution:
+      {
+        integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==,
+      }
+    dependencies:
+      "@vitest/utils": 4.1.4
+      pathe: 2.0.3
+    dev: true
+
+  /@vitest/snapshot@4.1.4:
+    resolution:
+      {
+        integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==,
+      }
+    dependencies:
+      "@vitest/pretty-format": 4.1.4
+      "@vitest/utils": 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+    dev: true
+
+  /@vitest/spy@4.1.4:
+    resolution:
+      {
+        integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==,
+      }
+    dev: true
+
+  /@vitest/utils@4.1.4:
+    resolution:
+      {
+        integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==,
+      }
+    dependencies:
+      "@vitest/pretty-format": 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+    dev: true
+
+  /assertion-error@2.0.1:
+    resolution:
+      {
+        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
+      }
+    engines: { node: ">=12" }
     dev: true
 
   /baseline-browser-mapping@2.10.18:
@@ -1084,6 +1221,14 @@ packages:
       {
         integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==,
       }
+    dev: true
+
+  /chai@6.2.2:
+    resolution:
+      {
+        integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
+      }
+    engines: { node: ">=18" }
     dev: true
 
   /convert-source-map@2.0.0:
@@ -1127,6 +1272,21 @@ packages:
     resolution:
       {
         integrity: sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==,
+      }
+    dev: true
+
+  /entities@7.0.1:
+    resolution:
+      {
+        integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==,
+      }
+    engines: { node: ">=0.12" }
+    dev: true
+
+  /es-module-lexer@2.0.0:
+    resolution:
+      {
+        integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==,
       }
     dev: true
 
@@ -1174,6 +1334,38 @@ packages:
     engines: { node: ">=6" }
     dev: true
 
+  /estree-walker@3.0.3:
+    resolution:
+      {
+        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+      }
+    dependencies:
+      "@types/estree": 1.0.8
+    dev: true
+
+  /expect-type@1.3.0:
+    resolution:
+      {
+        integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
+      }
+    engines: { node: ">=12.0.0" }
+    dev: true
+
+  /fdir@6.5.0(picomatch@4.0.4):
+    resolution:
+      {
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+      }
+    engines: { node: ">=12.0.0" }
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+    dependencies:
+      picomatch: 4.0.4
+    dev: true
+
   /fsevents@2.3.2:
     resolution:
       {
@@ -1202,6 +1394,24 @@ packages:
         integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
       }
     engines: { node: ">=6.9.0" }
+    dev: true
+
+  /happy-dom@20.9.0:
+    resolution:
+      {
+        integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==,
+      }
+    engines: { node: ">=20.0.0" }
+    dependencies:
+      "@types/node": 20.19.0
+      "@types/whatwg-mimetype": 3.0.2
+      "@types/ws": 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: true
 
   /js-tokens@4.0.0:
@@ -1246,6 +1456,15 @@ packages:
       yallist: 3.1.1
     dev: true
 
+  /magic-string@0.30.21:
+    resolution:
+      {
+        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
+    dependencies:
+      "@jridgewell/sourcemap-codec": 1.5.5
+    dev: true
+
   /ms@2.1.3:
     resolution:
       {
@@ -1269,6 +1488,13 @@ packages:
       }
     dev: true
 
+  /obug@2.1.1:
+    resolution:
+      {
+        integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+      }
+    dev: true
+
   /oidc-client-ts@3.1.0:
     resolution:
       {
@@ -1279,11 +1505,26 @@ packages:
       jwt-decode: 4.0.0
     dev: false
 
+  /pathe@2.0.3:
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
+    dev: true
+
   /picocolors@1.1.1:
     resolution:
       {
         integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
       }
+    dev: true
+
+  /picomatch@4.0.4:
+    resolution:
+      {
+        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
+      }
+    engines: { node: ">=12" }
     dev: true
 
   /playwright-core@1.49.1:
@@ -1455,12 +1696,67 @@ packages:
       }
     dev: false
 
+  /siginfo@2.0.0:
+    resolution:
+      {
+        integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
+      }
+    dev: true
+
   /source-map-js@1.2.1:
     resolution:
       {
         integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
       }
     engines: { node: ">=0.10.0" }
+    dev: true
+
+  /stackback@0.0.2:
+    resolution:
+      {
+        integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
+      }
+    dev: true
+
+  /std-env@4.1.0:
+    resolution:
+      {
+        integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==,
+      }
+    dev: true
+
+  /tinybench@2.9.0:
+    resolution:
+      {
+        integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
+      }
+    dev: true
+
+  /tinyexec@1.1.1:
+    resolution:
+      {
+        integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==,
+      }
+    engines: { node: ">=18" }
+    dev: true
+
+  /tinyglobby@0.2.16:
+    resolution:
+      {
+        integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==,
+      }
+    engines: { node: ">=12.0.0" }
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+    dev: true
+
+  /tinyrainbow@3.1.0:
+    resolution:
+      {
+        integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
+      }
+    engines: { node: ">=14.0.0" }
     dev: true
 
   /turbo-stream@2.4.0:
@@ -1549,6 +1845,112 @@ packages:
       rollup: 4.60.1
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
+
+  /vitest@4.1.4(@types/node@20.19.0)(happy-dom@20.9.0)(vite@6.0.7):
+    resolution:
+      {
+        integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==,
+      }
+    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
+    hasBin: true
+    peerDependencies:
+      "@edge-runtime/vm": "*"
+      "@opentelemetry/api": ^1.9.0
+      "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+      "@vitest/browser-playwright": 4.1.4
+      "@vitest/browser-preview": 4.1.4
+      "@vitest/browser-webdriverio": 4.1.4
+      "@vitest/coverage-istanbul": 4.1.4
+      "@vitest/coverage-v8": 4.1.4
+      "@vitest/ui": 4.1.4
+      happy-dom: "*"
+      jsdom: "*"
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      "@edge-runtime/vm":
+        optional: true
+      "@opentelemetry/api":
+        optional: true
+      "@types/node":
+        optional: true
+      "@vitest/browser-playwright":
+        optional: true
+      "@vitest/browser-preview":
+        optional: true
+      "@vitest/browser-webdriverio":
+        optional: true
+      "@vitest/coverage-istanbul":
+        optional: true
+      "@vitest/coverage-v8":
+        optional: true
+      "@vitest/ui":
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      "@types/node": 20.19.0
+      "@vitest/expect": 4.1.4
+      "@vitest/mocker": 4.1.4(vite@6.0.7)
+      "@vitest/pretty-format": 4.1.4
+      "@vitest/runner": 4.1.4
+      "@vitest/snapshot": 4.1.4
+      "@vitest/spy": 4.1.4
+      "@vitest/utils": 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      happy-dom: 20.9.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 6.0.7(@types/node@20.19.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+    dev: true
+
+  /whatwg-mimetype@3.0.0:
+    resolution:
+      {
+        integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==,
+      }
+    engines: { node: ">=12" }
+    dev: true
+
+  /why-is-node-running@2.3.0:
+    resolution:
+      {
+        integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
+      }
+    engines: { node: ">=8" }
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+    dev: true
+
+  /ws@8.20.0:
+    resolution:
+      {
+        integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==,
+      }
+    engines: { node: ">=10.0.0" }
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ">=5.0.2"
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
     dev: true
 
   /yallist@3.1.1:


### PR DESCRIPTION
## Summary

LAN end-to-end smoke was broken by three stacked bugs. This PR fixes all three, adds the regression tests that would have caught each of them, and hardens CLAUDE.md Rule 2 with the test-first discipline that would have prevented the incident.

### The three bugs (top-down by transport layer)

1. **Engine gRPC server had no keepalive policy.** Gateway client keepalive (ADR-0006, 30 s) tripped the C++ default "≥ 5 min between pings"; every LAN session died every ~4 min with `ENHANCE_YOUR_CALM` / GOAWAY and the whisper model reloaded from scratch. Fix: two `GRPC_ARG_*` channel args.
2. **`Session::Run` was batch, not streaming.** Accumulated PCM for the whole stream, emitted one segment at Stage 5 after END_STREAM. Live listeners saw nothing. Fix: `flush_window` helper with 3 s non-overlapping windows; monotonic `segment_id` from 1; `start_ms`/`end_ms` derived from cumulative sample offsets.
3. **Frontend `WebSocketTranscriptStreamProvider` dropped binary frames.** Phase-1 stub only handled string frames. Gateway sends binary protobuf ViewerEvent. Browser ArrayBuffer check `typeof ev.data === "string"` was false → silent drop. In-file comment literally said "Phase 2 decodes real protobuf". Fix: `ViewerEvent.fromBinary` + enum/bigint mapping; malformed binary and stray text frames surface via `onError` instead of silent-drop.

### Regression tests added alongside (CLAUDE.md Rule 2 test-first)

- **10 Vitest cases** for Layer 3: `WebSocketTranscriptStreamProvider.test.ts` covers binary decode of every `ViewerEvent` payload variant, malformed-binary → onError, string-frame → onError, unsubscribe idempotent, onClose forwarded, binaryType precondition, URL encoding.
- **New C++ integration test** for Layer 2: `StreamTranscribeTest.LiveWindowEmitsMidStream` feeds JFK audio, asserts > 1 segment emitted before stream close (batch-mode was exactly 1), monotonic segment_ids, non-zero spans.
- **Refactored** `StreamTranscribeTest.JfkEndToEnd` to background-reader pattern — under live windowing the server writes egress mid-stream; single-threaded client tests deadlock on in-process gRPC channel's bounded buffers.
- **Layer 1 (keepalive) stays uncovered by UT** — the bug is cross-process HTTP/2 protocol timing and cannot be reproduced in-process. Incident 14 §Lessons explicitly names this; future detection relies on long-running staging canary.

### Observability — audio path no longer silent

Pipeline + webrtc packages had zero `slog` calls pre-fix. Added lifecycle logs keyed on `session_id` for every hop from OnTrack → engine stream open → session start → first audio frame → first egress → stream close → broadcast fan-out. The `stream_closed_err` path was previously a bare `return` that swallowed every engine-side failure; now logs at Warn with err + counters.

### CLAUDE.md Rule 2 — test-first commit discipline

Three new bullets under §Testing Integrity:
- Regression test MUST land in the same commit as the fix.
- Testing escape hatches (UT genuinely can't catch) must be named in the PR body.
- `bazel test //...` MUST be green before `git commit`, not just before PR merge.

### Infrastructure additions

- **Vitest** — first Vitest target in the tree. `frontend_web/package.json` gains vitest + happy-dom + `test` script; `vite.config.ts` grows a shared `test` block scoped to `src/**/*.test.{ts,tsx}`.
- **Integration test CAS migration** — `stream_transcribe_test.cc`, `whisper_transcribe_test.cc`, `bge_m3_embed_test.cc` had `ResolveModelPath` hardcoded to the pre-ADR-0026 flat path. After PR #51's CAS migration, those tests had been silently SKIP'ing. Each now tries CAS first, falls back to legacy for stale local setups.

### Verification

- `bazel test //engine_cpp/... //gateway_go/...`: **24/24 pass** (3 integration tests gated on AEGIS_MODEL_DIR run green locally).
- `./tools/scripts/frontend.sh test` (new): **10/10 Vitest pass**.
- `./tools/scripts/frontend.sh typecheck`: clean.
- LAN end-to-end smoke: speak → host UI shows transcript every ~3 s.

## Test plan

- [x] C++ unit tests pass
- [x] C++ integration tests pass (gated on model presence)
- [x] Go tests pass
- [x] Vitest pass (10/10)
- [x] Frontend typecheck clean
- [x] LAN smoke manual: transcript renders live
- [x] CLAUDE.md Rule 2 updated with test-first discipline
- [x] docs/incidents.md §14 postmortem added

### Testing escape hatch (Rule 2 new)

Layer 1 (engine gRPC keepalive policy) is not covered by UT. Cross-process HTTP/2 protocol timing cannot be reproduced in a single-process test. Future detection: staging canary with > 5 min idle bidi stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)