### PR TITLE
docs(security-ladder): scope Checkov to misconfig axis, keep gitleaks as secret-scan primary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -329,7 +329,7 @@ The engine image is built by CI on Linux runners; Camp B trust means no defensiv
 #### 10.3 Dynamic & Runtime Analysis
 
 - **Container scanning**: `Trivy` scans every built image for known CVEs. High / critical findings block image push to ECR. **Live as of Phase 4b mini-slice 2**: `aquasecurity/trivy-action` SHA-pinned in `release-staging-image.yml` scans gateway + engine images by `@sha256:` digest after Cosign sign; initial threshold `severity: CRITICAL` with `ignore-unfixed: true`; tighten to `HIGH,CRITICAL` is a one-line change. ADR-0029.
-- **Kubernetes manifest scanning**: `kube-score` + `kube-bench` validate manifests against CIS Kubernetes Benchmarks before ArgoCD sync.
+- **Kubernetes manifest & IaC scanning**: `kube-score` + `kube-bench` validate manifests against CIS Kubernetes Benchmarks before ArgoCD sync; `Checkov` adds policy-as-code misconfiguration checks on K8s manifests + Dockerfile + Helm charts (rejects `privileged: true`, missing `runAsNonRoot`, `hostPath` volumes, `:latest` image tags, missing resource limits, etc.). Checkov is scoped to the **misconfig / policy-as-code axis** — its built-in `CKV_SECRET_*` rules are incidental overlap, not the primary layer; secret-in-source defense lives in `gitleaks` + GitHub push protection (below), and plain-text secrets in K8s `Secret.data` are prevented architecturally by External Secrets Operator, not by post-hoc scan.
 - **Secret scanning**: `gitleaks` pre-commit hook (local) + **GitHub secret scanning with push protection** (server-side) catch committed credentials.
 - **DAST** (post-MVP): `OWASP ZAP` or equivalent runs against staging deployments on a schedule.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -319,7 +319,7 @@ Gated by 3b — prompter display needs real transcript data; corpus selector nee
 - [x] Trivy container scan; block push on critical CVEs (ADR-0029) — `aquasecurity/trivy-action` SHA-pinned scans gateway + engine images by `@sha256:` digest after push (no tag-race), `severity: CRITICAL` + `ignore-unfixed: true` initial threshold; `exit-code: 1` blocks workflow on CRITICAL findings. Tighten to `HIGH,CRITICAL` is a one-line change when ops bandwidth supports the triage.
 - [x] Verify no binary contains `AEGIS_DEV_AUDIO_DUMP` symbol (ADR-0005 R7) — Bazel `sh_test` `//engine_cpp/tests/unit:no_dev_audio_dump_symbol_test` greps the linked engine binary for the string; passes in default fastbuild, fails under `--config=debug`. Included in PR CI via `ci-baseline.yml` → `bazel test`; `--strip=always` on release strips symbols but not `.rodata`, so the string survives stripping and the gate still detects leaked copts.
 - [ ] kube-score + kube-bench manifest scan
-- [ ] Checkov IaC scanner for K8s manifests + Dockerfile + Helm charts (complements kube-score/kube-bench from the misconfiguration / policy-as-code angle; see debrief discussion 2026-04-12)
+- [ ] Checkov IaC scanner for K8s manifests + Dockerfile + Helm charts (complements kube-score/kube-bench from the misconfiguration / policy-as-code angle — **not** a secret-scan layer; `gitleaks` + GitHub push protection remain primary per `ARCHITECTURE.md` §10.3; see debrief discussion 2026-04-12)
 - [ ] CodeQL, Semgrep, gosec, govulncheck, clang-tidy in CI (ARCH §10.2)
 - [ ] ECR push pipeline; ArgoCD in `aegis-aws-landing-zone` repository polls the manifests in this repository
 


### PR DESCRIPTION
## Summary

- `ARCHITECTURE.md:332` §10.3 now documents Checkov alongside kube-score / kube-bench, scoped explicitly to the **misconfig / policy-as-code axis** (privileged, runAsNonRoot, hostPath, :latest tags, resource limits) and calls out that its `CKV_SECRET_*` rules are incidental overlap — not a replacement for `gitleaks` + GitHub push protection.
- `ROADMAP.md:322` checklist item for Checkov mirrors the same scoping and links back to ARCH §10.3 so whoever picks up that TODO can't mistake Checkov for a third secret-scan layer.

## Why

Phase 4 hardening will introduce Checkov (`ROADMAP.md:322`). Without the scoping note, a future reader comparing Checkov's built-in `detect-secrets` coverage against `gitleaks` could reasonably conclude Checkov is a replacement or redundancy candidate. It isn't — plain-text secrets in `Secret.data` are prevented architecturally by External Secrets Operator, not by post-hoc scan.

## Test plan
- [x] `pre-commit` hooks pass (trailing whitespace, EOF, secret scan, conventional commit)
- [x] No code changed — doc-only
- [x] Cross-reference between ARCH §10.3 and ROADMAP §Phase 4 is bidirectional (ROADMAP points at ARCH §10.3)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)