### PR TITLE
fix(rag-demo): gate retriever hints on min_score + dedupe; clear viewer error latch

### DIFF
--- a/engine_cpp/src/rag/retriever.cc
+++ b/engine_cpp/src/rag/retriever.cc
@@ -74,10 +74,34 @@ Retriever::Retrieve(std::string_view transcript_text) {
         absl::StrCat("Retriever: no matches in '", collection_, "'"));
   }
 
+  const auto &top = results->front();
+
+  // Score gate — Qdrant top-K always returns K results if the
+  // collection has ≥ K points, regardless of relevance. Without
+  // this check, every filler utterance ("um", "let me think") fires
+  // a hint with the nearest-but-irrelevant chunk. See Config::min_score.
+  if (top.score < config_.min_score) {
+    return absl::NotFoundError(
+        absl::StrFormat("Retriever: top score %.3f below min_score %.3f",
+                        top.score, config_.min_score));
+  }
+
+  // Consecutive-same-topic dedupe. When a speaker stays on one topic
+  // across multiple 3 s flush windows the top match is usually the
+  // same chunk; re-emitting it every window spams the viewer with
+  // an identical suggestion. Suppress when the top point id matches
+  // the last emission; let A → B → A through (intentional topic
+  // return). Empty last_top_point_id_ (first call) always passes.
+  if (top.id == last_top_point_id_) {
+    return absl::NotFoundError(
+        absl::StrCat("Retriever: top match '", top.id,
+                     "' matches last emission (same-topic dedupe)"));
+  }
+  last_top_point_id_ = top.id;
+
   aegis::v1::PrompterHint hint;
   hint.set_hint_id(next_hint_id_++);
 
-  const auto &top = results->front();
   const std::string top_text = LookupPayload(top.payload, "text");
   hint.set_suggestion(ClipExcerpt(top_text, config_.excerpt_bytes));
   hint.set_rationale(absl::StrFormat("Related context from '%s' (score=%.3f)",

--- a/engine_cpp/src/rag/retriever.h
+++ b/engine_cpp/src/rag/retriever.h
@@ -52,6 +52,19 @@ public:
     // signal. 240 bytes ≈ 80 CJK characters or 240 ASCII characters,
     // matches the chunker's overlap window (ADR-0019 §Decision.2).
     std::size_t excerpt_bytes = 240;
+
+    // Minimum cosine-similarity score for a hint to be emitted.
+    // Qdrant's top-K search always returns K results when the
+    // collection has ≥ K points, regardless of how far off-topic the
+    // query is — without this threshold every 3 s transcript window
+    // fires a hint even when the speaker says "um, let me think" and
+    // the viewer UI overwrites with garbage. 0.42 is conservative
+    // for bge-m3 multilingual (zh-TW tokens are semantic-dense; the
+    // 0.40–0.50 band is industry-standard "meaningful match" vs
+    // "random noise"). Tune higher to be stricter; set to 0 to
+    // disable the gate entirely (pre-gate behaviour for regression
+    // bisection).
+    float min_score = 0.42f;
   };
 
   // `embedder` and `searcher` must outlive this Retriever. `collection`
@@ -72,9 +85,13 @@ public:
   // starting at 1.
   //
   // Status codes:
-  //   NotFound         — empty transcript, OR search returned zero
-  //                      results. Caller treats as "no hint to emit";
-  //                      session continues.
+  //   NotFound         — empty transcript; OR search returned zero
+  //                      results; OR top match scored below
+  //                      `config_.min_score`; OR top match is the
+  //                      same Qdrant point id as the previous
+  //                      emission (consecutive-same-topic dedupe).
+  //                      Caller treats as "no hint to emit"; session
+  //                      continues.
   //   InvalidArgument  — embedder produced an empty vector.
   //   (propagated)     — whatever the embedder or searcher surfaced.
   absl::StatusOr<aegis::v1::PrompterHint>
@@ -91,6 +108,15 @@ private:
   std::string collection_;
   Config config_;
   std::uint64_t next_hint_id_ = 1;
+
+  // Dedupe state: the Qdrant point id of the top result last emitted
+  // as a hint. Consecutive Retrieve() calls whose top match is the
+  // SAME point id return NotFound — a speaker staying on the same
+  // topic should not flood the viewer with the same corpus chunk
+  // every 3 s. Cleared back to the new top whenever a different
+  // point wins, so A → B → A is three distinct emissions (topic
+  // changed away and back).
+  std::string last_top_point_id_;
 };
 
 } // namespace aegis::rag

--- a/engine_cpp/tests/unit/retriever_test.cc
+++ b/engine_cpp/tests/unit/retriever_test.cc
@@ -126,20 +126,98 @@ TEST(RetrieverTest, BuildsHintFromTopMatchWithCitations) {
 TEST(RetrieverTest, HintIdsAreMonotonicStartingAtOne) {
   FakeEmbedder e;
   FakeVectorSearcher s;
-  s.results_ = {
-      MakeResult("uuid-1", 0.9f, "ctx", "doc.md", "0"),
-  };
-
   Retriever r(&e, &s, "aegis_col");
+
+  // Distinct point ids per call — otherwise the same-topic dedupe
+  // (Retriever::last_top_point_id_) suppresses h2 and h3.
+  s.results_ = {MakeResult("uuid-a", 0.9f, "ctx a", "doc.md", "0")};
   auto h1 = r.Retrieve("first");
+  s.results_ = {MakeResult("uuid-b", 0.9f, "ctx b", "doc.md", "1")};
   auto h2 = r.Retrieve("second");
+  s.results_ = {MakeResult("uuid-c", 0.9f, "ctx c", "doc.md", "2")};
   auto h3 = r.Retrieve("third");
+
   ASSERT_TRUE(h1.ok()) << h1.status();
   ASSERT_TRUE(h2.ok()) << h2.status();
   ASSERT_TRUE(h3.ok()) << h3.status();
   EXPECT_EQ(h1->hint_id(), 1u);
   EXPECT_EQ(h2->hint_id(), 2u);
   EXPECT_EQ(h3->hint_id(), 3u);
+}
+
+TEST(RetrieverTest, TopScoreBelowMinScoreReturnsNotFound) {
+  FakeEmbedder e;
+  FakeVectorSearcher s;
+  // Default min_score is 0.42; 0.30 is below the gate.
+  s.results_ = {MakeResult("uuid-low", 0.30f, "mediocre match", "doc.md", "0")};
+
+  Retriever r(&e, &s, "aegis_col");
+  auto h = r.Retrieve("ambient chatter that doesn't match the corpus");
+  ASSERT_FALSE(h.ok());
+  EXPECT_EQ(h.status().code(), absl::StatusCode::kNotFound);
+  EXPECT_NE(h.status().message().find("min_score"), std::string::npos)
+      << "NotFound message must mention min_score for operator debuggability";
+}
+
+TEST(RetrieverTest, MinScoreThresholdIsConfigurable) {
+  FakeEmbedder e;
+  FakeVectorSearcher s;
+  s.results_ = {MakeResult("uuid-mid", 0.35f, "borderline", "doc.md", "0")};
+
+  // Lower the gate to 0.30 — the same 0.35 result now passes.
+  Retriever::Config cfg;
+  cfg.min_score = 0.30f;
+  Retriever r(&e, &s, "aegis_col", cfg);
+  auto h = r.Retrieve("query");
+  ASSERT_TRUE(h.ok()) << h.status();
+  EXPECT_EQ(h->suggestion(), "borderline");
+}
+
+TEST(RetrieverTest, ConsecutiveSameTopPointIsDedupedToNotFound) {
+  FakeEmbedder e;
+  FakeVectorSearcher s;
+  // Same top point id on both calls — simulates a speaker staying on
+  // one topic across two 3 s flush windows.
+  s.results_ = {
+      MakeResult("uuid-same", 0.9f, "Taiwan climate is subtropical.", "doc.md",
+                 "0"),
+  };
+
+  Retriever r(&e, &s, "aegis_col");
+  auto h1 = r.Retrieve("what is the climate in Taiwan?");
+  ASSERT_TRUE(h1.ok()) << h1.status();
+
+  auto h2 = r.Retrieve("tell me about Taiwan's climate again");
+  ASSERT_FALSE(h2.ok());
+  EXPECT_EQ(h2.status().code(), absl::StatusCode::kNotFound);
+  EXPECT_NE(h2.status().message().find("dedupe"), std::string::npos)
+      << "NotFound message must name the dedupe condition";
+}
+
+TEST(RetrieverTest, TopicReturnSequenceABABaEmitsEachTime) {
+  FakeEmbedder e;
+  FakeVectorSearcher s;
+  Retriever r(&e, &s, "aegis_col");
+
+  auto result_a = MakeResult("uuid-A", 0.9f, "ctx A", "doc.md", "0");
+  auto result_b = MakeResult("uuid-B", 0.9f, "ctx B", "doc.md", "1");
+
+  // A → B → A should all emit — dedupe only suppresses consecutive
+  // same-top, not the whole history.
+  s.results_ = {result_a};
+  auto h1 = r.Retrieve("first mention of A");
+  ASSERT_TRUE(h1.ok()) << h1.status();
+  EXPECT_EQ(h1->suggestion(), "ctx A");
+
+  s.results_ = {result_b};
+  auto h2 = r.Retrieve("pivot to B");
+  ASSERT_TRUE(h2.ok()) << h2.status();
+  EXPECT_EQ(h2->suggestion(), "ctx B");
+
+  s.results_ = {result_a};
+  auto h3 = r.Retrieve("return to A");
+  ASSERT_TRUE(h3.ok()) << h3.status();
+  EXPECT_EQ(h3->suggestion(), "ctx A");
 }
 
 TEST(RetrieverTest, EmptyTranscriptReturnsNotFound) {

--- a/frontend_web/src/pages/Viewer/ViewerPage.tsx
+++ b/frontend_web/src/pages/Viewer/ViewerPage.tsx
@@ -69,6 +69,15 @@ export function ViewerPage(): JSX.Element {
     if (!sessionId || !token) return;
 
     const onEvent = (event: ViewerEvent): void => {
+      // Clear any prior stream error on successful receipt. Without
+      // this, a transient `onError` call (e.g. the stray-text-frame
+      // warning surfaced per Incident 14's string-frame contract
+      // violation path, or a one-off malformed binary) latches the
+      // red "Stream error" banner forever, even though every
+      // subsequent transcript / hint frame arrives correctly. A
+      // healthy stream proves itself with each successful event;
+      // treat that as evidence the prior error was transient.
+      setError(null);
       switch (event.kind) {
         case "transcript":
           setTranscript((prev) => {


### PR DESCRIPTION
## Summary

Two demo-polish fixes from the first LAN smoke drive. Neither blocked the demo; both were visible enough to be mentioned.

### Issue 3 — retriever spams hint every 3 s window

\`engine_cpp/src/rag/retriever.{h,cc}\`: Qdrant top-K always returns K results when the collection has ≥ K points — so every 3-second flush window fired a hint regardless of relevance. Filler speech ("um, let me think") produced garbage suggestions; topic continuity repeated the same chunk over and over.

Two-layer gate:

- **\`Config::min_score\`** (default 0.42f, tunable; 0 disables) — cosine-similarity threshold below which the top result returns NotFound. Rationale inline: bge-m3 multilingual puts "random noise" below 0.40–0.50; 0.42 is the conservative edge.
- **\`Retriever::last_top_point_id_\`** — consecutive \`Retrieve()\` calls whose top match is the SAME Qdrant point id return NotFound (dedupe). A → B → A still emits all three; dedupe is consecutive-only.

Four new tests in \`retriever_test.cc\` + existing \`HintIdsAreMonotonicStartingAtOne\` updated (distinct point ids now required per call since dedupe would otherwise suppress h2/h3).

### Issue 1 — viewer "Stream error" banner latches forever

\`frontend_web/src/pages/Viewer/ViewerPage.tsx\`: \`onError\` sets error state; no path clears it, so a single transient error (e.g. the Incident-14 stray-text-frame warning path, one-off malformed binary) leaves the red banner up even while every subsequent transcript + hint arrives correctly.

Fix: prepend \`setError(null)\` to \`onEvent\`. A healthy stream proves itself with each successful event.

## Test plan

- [x] \`bazel test //engine_cpp/tests/unit:retriever_test\` — PASSED in 0.5s (12 tests: 7 existing + 5 new/updated)
- [x] \`tools/scripts/frontend.sh typecheck\` — clean
- [x] Pre-commit hooks pass (including clang-format auto-fix pass)
- [ ] CI green
- [ ] **User re-drive**: run LAN smoke again; speak a known off-topic utterance (should NOT fire a hint); speak about Taiwan twice in a row (should fire once, not twice on the same chunk); cause the provider to surface a transient error and confirm the banner clears on next transcript/hint frame

## Testing escape hatch (CLAUDE.md Rule 2)

No regression test for the ViewerPage change: the file has no React Testing Library harness today (only Playwright for e2e + Vitest for provider-level unit tests). Standing up RTL for a 1-line fix is disproportionate. Structural coverage for this class of bug is the ROADMAP Phase 4c "Post-deploy E2E suite against staging" slice.

## Not in this PR

- **Issue 2 (chunker boundaries)** — mid-sentence starts + "## 地理與氣候" header run-ons need a real chunker rework. Own PR. Larger blast radius (changes retrieval quality for every seed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)