### PR TITLE
fix(chunker): markdown-aware segmentation + sentence-aware overlap walk

### DIFF
--- a/docs/adr/0019-rag-corpus-and-embedding-pipeline.md
+++ b/docs/adr/0019-rag-corpus-and-embedding-pipeline.md
@@ -97,6 +97,25 @@ choices:
    Target chunk size ≈ 450 characters; overlap ≈ 80. No word-based
    splitter — Chinese has no word boundaries and naive tokenization
    mangles sentences.
+
+   > **Amendment — 2026-04-22 (post-LAN-smoke demo polish).** Two
+   > orthogonal rules added on top of the separator cascade, neither
+   > altering the 450/80 sizing contract:
+   > - **Markdown-aware segmentation.** Lines matching `^#+\s+` are
+   >   HARD segment boundaries — chunks never merge across a header,
+   >   and overlap prefixes never cross one. The header line joins
+   >   the section BELOW it. Trigger: 2026-04-21 LAN smoke produced
+   >   `"...130公里...## 地理與氣候臺灣島的總..."` when overlap pulled
+   >   the `概覽` section's tail through the `## 地理與氣候` header
+   >   into the next chunk's prefix. Opt-out via
+   >   `Config::respect_markdown_headers = false` for plain-text
+   >   corpora.
+   > - **Sentence-aware overlap walk.** After computing the raw last-N-char
+   >   tail, walk forward up to `Config::overlap_boundary_search_chars`
+   >   UTF-8 code points (default 40) to the next `。/！/？/\n` and
+   >   start the overlap prefix there. `，` is intentionally NOT a
+   >   boundary — intra-sentence, starting the prefix there still
+   >   strands readers mid-thought.
 3. **Embeddings**: `BAAI/bge-m3` via `FlagEmbedding`. Open weights,
    runs locally on Apple Silicon via sentence-transformers-compatible
    tooling, multilingual across 100+ languages, 1024-dim dense

--- a/engine_cpp/src/rag/chunker.cc
+++ b/engine_cpp/src/rag/chunker.cc
@@ -197,19 +197,66 @@ std::vector<Chunk> SplitRecursive(std::string_view text,
   return out;
 }
 
+// Walk forward from `raw_start_byte` through up to `max_walk_chars`
+// UTF-8 code points of `text`, looking for a sentence-ending mark
+// (`。`, `！`, `？`, `\n`). If found, return the byte offset
+// IMMEDIATELY AFTER that mark (so the overlap tail starts on the
+// next sentence). If no mark is found within the budget, return
+// `raw_start_byte` unchanged (caller falls back to the raw tail).
+//
+// `，` is intentionally NOT a boundary: CJK comma is intra-sentence,
+// and starting a chunk prefix just after `，` still strands readers
+// mid-thought. The goal is a CLEAN sentence start.
+std::size_t WalkForwardToSentenceStart(std::string_view text,
+                                       std::size_t raw_start_byte,
+                                       std::size_t max_walk_chars) {
+  if (max_walk_chars == 0 || raw_start_byte >= text.size())
+    return raw_start_byte;
+
+  static constexpr std::string_view kSentenceEnds[] = {
+      "。",
+      "！",
+      "？",
+      "\n",
+  };
+
+  std::size_t pos = raw_start_byte;
+  std::size_t walked = 0;
+  while (pos < text.size() && walked < max_walk_chars) {
+    for (const auto &end : kSentenceEnds) {
+      if (text.size() - pos >= end.size() &&
+          text.substr(pos, end.size()) == end) {
+        return pos + end.size();
+      }
+    }
+    pos += Utf8CharByteLen(static_cast<unsigned char>(text[pos]));
+    ++walked;
+  }
+  return raw_start_byte;
+}
+
 // Second pass: apply overlap by prepending the last `overlap_chars`
-// UTF-8 code points of chunk N to the front of chunk N+1.
-// Byte offset for chunk N+1 moves back by the overlap length.
-void ApplyOverlap(std::vector<Chunk> &chunks, std::size_t overlap_chars) {
+// UTF-8 code points of chunk N to the front of chunk N+1. When
+// `boundary_search_chars` > 0, walk the tail start forward to the
+// next sentence boundary so the prefix begins cleanly. Overlap is
+// only applied WITHIN a segment — the caller is responsible for
+// splitting inputs on header boundaries before calling this.
+// Byte offset for chunk N+1 moves back by the effective tail's byte length.
+void ApplyOverlap(std::vector<Chunk> &chunks, std::size_t overlap_chars,
+                  std::size_t boundary_search_chars) {
   if (overlap_chars == 0 || chunks.size() < 2)
     return;
   for (std::size_t i = 1; i < chunks.size(); ++i) {
     const Chunk &prev = chunks[i - 1];
-    const std::size_t overlap_start_byte_in_prev =
+    const std::size_t raw_start =
         Utf8DropAllButLastChars(prev.text, overlap_chars);
+    const std::size_t boundary_start =
+        WalkForwardToSentenceStart(prev.text, raw_start, boundary_search_chars);
     const std::string_view tail =
-        std::string_view(prev.text).substr(overlap_start_byte_in_prev);
+        std::string_view(prev.text).substr(boundary_start);
     const std::size_t tail_chars = Utf8CharCount(tail);
+    if (tail.empty())
+      continue; // Entire raw tail was skipped past — no overlap this step.
 
     Chunk &cur = chunks[i];
     std::string stitched;
@@ -222,6 +269,46 @@ void ApplyOverlap(std::vector<Chunk> &chunks, std::size_t overlap_chars) {
         cur.byte_offset >= tail.size() ? cur.byte_offset - tail.size() : 0;
     cur.char_count += tail_chars;
   }
+}
+
+// Segment `text` on markdown ATX headers — lines matching
+// `^#+\s+`. Each returned pair is `[start_byte, end_byte)` covering
+// a contiguous segment; the header line joins the segment BELOW it
+// (its own section's content). The first segment starts at byte 0
+// (and may precede any header — e.g., the HTML comment at the top
+// of `docs/rag/taiwan.md`).
+//
+// Byte-level scanning is intentional: ASCII `\n` (0x0A) and `#`
+// (0x23) never appear as UTF-8 continuation bytes, so this finds
+// header lines correctly regardless of CJK content in between.
+std::vector<std::pair<std::size_t, std::size_t>>
+SegmentOnHeaders(std::string_view text) {
+  std::vector<std::size_t> boundaries;
+  boundaries.push_back(0);
+
+  for (std::size_t pos = 0; pos < text.size(); ++pos) {
+    const bool at_line_start = (pos == 0 || text[pos - 1] == '\n');
+    if (!at_line_start || text[pos] != '#')
+      continue;
+    std::size_t hash_end = pos;
+    while (hash_end < text.size() && text[hash_end] == '#')
+      ++hash_end;
+    if (hash_end < text.size() &&
+        (text[hash_end] == ' ' || text[hash_end] == '\t')) {
+      if (pos > 0)
+        boundaries.push_back(pos);
+    }
+  }
+
+  std::vector<std::pair<std::size_t, std::size_t>> segments;
+  segments.reserve(boundaries.size());
+  for (std::size_t i = 0; i < boundaries.size(); ++i) {
+    const std::size_t start = boundaries[i];
+    const std::size_t end =
+        (i + 1 < boundaries.size()) ? boundaries[i + 1] : text.size();
+    segments.emplace_back(start, end);
+  }
+  return segments;
 }
 
 } // namespace
@@ -243,10 +330,31 @@ MarkdownChunker::MarkdownChunker(Config config) : config_(std::move(config)) {}
 std::vector<Chunk> MarkdownChunker::Split(std::string_view markdown) const {
   if (markdown.empty())
     return {};
-  auto chunks = SplitRecursive(markdown, /*base_byte_offset=*/0,
-                               config_.target_chunk_chars, config_.separators);
-  ApplyOverlap(chunks, config_.overlap_chars);
-  return chunks;
+
+  std::vector<std::pair<std::size_t, std::size_t>> segments;
+  if (config_.respect_markdown_headers) {
+    segments = SegmentOnHeaders(markdown);
+  } else {
+    segments.emplace_back(0, markdown.size());
+  }
+
+  std::vector<Chunk> all_chunks;
+  for (const auto &[seg_start, seg_end] : segments) {
+    const std::string_view seg =
+        markdown.substr(seg_start, seg_end - seg_start);
+    if (seg.empty())
+      continue;
+    auto seg_chunks = SplitRecursive(seg, seg_start, config_.target_chunk_chars,
+                                     config_.separators);
+    // Overlap is applied ONLY within a segment — headers are hard
+    // boundaries, so overlap must not pull text across them.
+    ApplyOverlap(seg_chunks, config_.overlap_chars,
+                 config_.overlap_boundary_search_chars);
+    for (auto &c : seg_chunks) {
+      all_chunks.push_back(std::move(c));
+    }
+  }
+  return all_chunks;
 }
 
 } // namespace aegis::rag

--- a/engine_cpp/src/rag/chunker.h
+++ b/engine_cpp/src/rag/chunker.h
@@ -70,6 +70,31 @@ public:
     // here — Split() handles it automatically.
     std::vector<std::string> separators = {"\n\n", "\n", "。", "！",
                                            "？",   "，", " "};
+
+    // When true, treat lines matching `^#+\s+` (markdown ATX
+    // headers) as HARD segment boundaries: no chunk (including
+    // its overlap prefix) crosses a header. The header line
+    // joins the section BELOW it (its own section's content).
+    // Setting this false restores the v1 behavior where headers
+    // are just text — useful for plain-text corpora. Default true
+    // because the 2026-04-21 LAN smoke showed overlap pulling
+    // sentences from the previous section across `## 地理與氣候`
+    // into the next chunk's prefix, producing nonsensical excerpts
+    // like "130公里...## 地理與氣候臺灣島的總".
+    bool respect_markdown_headers = true;
+
+    // For `ApplyOverlap`: after computing the raw last-N-char tail
+    // of chunk N, walk FORWARD up to this many UTF-8 code points
+    // looking for a sentence boundary (`。`, `！`, `？`, `\n`).
+    // If one is found, the overlap tail begins AFTER that boundary
+    // — the overlap prefix of chunk N+1 then starts cleanly at a
+    // new sentence. If no boundary is found within the budget,
+    // fall back to the raw tail (v1 behavior). 0 disables the walk.
+    // Note: `，` (CJK comma) is intentionally NOT a boundary here —
+    // it's intra-sentence, so starting after a `，` still starts
+    // mid-thought. Default 40 is chosen to clear most zh-TW
+    // sentence-ends without making overlap unbounded.
+    std::size_t overlap_boundary_search_chars = 40;
   };
 
   MarkdownChunker();

--- a/engine_cpp/tests/unit/chunker_test.cc
+++ b/engine_cpp/tests/unit/chunker_test.cc
@@ -194,44 +194,178 @@ TEST(MarkdownChunkerCorpusTest, OverlapPresentBetweenAdjacentChunks) {
   ss << f.rdbuf();
   const std::string corpus = ss.str();
 
-  MarkdownChunker c; // default overlap=80
+  MarkdownChunker c; // default overlap=80, boundary_search=40
   auto chunks = c.Split(corpus);
   ASSERT_GE(chunks.size(), 2u);
 
-  // For each adjacent pair, verify the tail of chunk N appears at
-  // the start of chunk N+1 (that's what overlap means).
+  // Verify the minimum contract: SOME non-empty suffix of chunk N-1
+  // appears as a prefix of chunk N. (Exact tail length varies once
+  // the sentence-aware overlap walk is in play — the walk may shorten
+  // the tail to end cleanly at `。` / `\n`. "At least one adjacent
+  // pair overlaps by at least one byte" is the stable invariant; the
+  // exact size isn't.) Byte-level comparison — overlap is always
+  // copied byte-exact, so any suffix/prefix byte match is genuine.
   std::size_t overlaps_found = 0;
   for (std::size_t i = 1; i < chunks.size(); ++i) {
-    const std::string &prev = chunks[i - 1].text;
-    const std::string &cur = chunks[i].text;
-    // Extract the last 80 chars of prev (by bytes via Utf8 helpers).
-    const std::size_t prev_chars = Utf8CharCount(prev);
-    if (prev_chars <= 80)
-      continue; // prev is entirely within overlap — skip
-    // Find the byte start of the last 80 chars.
-    std::size_t chars_seen = 0;
-    std::size_t byte_pos = 0;
-    const std::size_t skip = prev_chars - 80;
-    while (byte_pos < prev.size() && chars_seen < skip) {
-      auto leading = static_cast<unsigned char>(prev[byte_pos]);
-      if (leading < 0x80)
-        byte_pos += 1;
-      else if (leading < 0xE0)
-        byte_pos += 2;
-      else if (leading < 0xF0)
-        byte_pos += 3;
-      else
-        byte_pos += 4;
-      ++chars_seen;
-    }
-    std::string_view tail(prev.data() + byte_pos, prev.size() - byte_pos);
-    // cur should start with this tail.
-    if (!tail.empty() && std::string_view(cur).substr(0, tail.size()) == tail) {
-      ++overlaps_found;
+    const std::string_view prev = chunks[i - 1].text;
+    const std::string_view cur = chunks[i].text;
+    const std::size_t max_len = std::min(prev.size(), cur.size());
+    for (std::size_t len = 1; len <= max_len; ++len) {
+      if (prev.substr(prev.size() - len) == cur.substr(0, len)) {
+        ++overlaps_found;
+        break;
+      }
     }
   }
   EXPECT_GE(overlaps_found, 1u)
       << "No overlap found between any adjacent chunk pair";
+}
+
+// --- Rework tests (2026-04-22): markdown-aware + sentence-aware overlap ---
+
+TEST(MarkdownChunkerTest, HeaderIsHardSegmentBoundary) {
+  // Section A has enough content that, with the v1 separator-only
+  // cascade, overlap would pull its tail across `## B` into the
+  // second chunk's prefix (producing "...A tail...## B B body").
+  // With respect_markdown_headers=true (default), the second chunk
+  // must NOT contain any text from section A.
+  MarkdownChunker c; // default: respect_markdown_headers = true
+  std::string input =
+      "## A\n\n"
+      "A body sentence one. A body sentence two. A body sentence three.\n\n"
+      "## B\n\n"
+      "B body sentence one. B body sentence two.";
+  auto chunks = c.Split(input);
+  ASSERT_GE(chunks.size(), 2u);
+
+  // The chunk containing "## B" must NOT contain any of "A body".
+  bool found_b_chunk = false;
+  for (const auto &ch : chunks) {
+    if (ch.text.find("## B") != std::string::npos) {
+      found_b_chunk = true;
+      EXPECT_EQ(ch.text.find("A body"), std::string::npos)
+          << "Header hard-boundary violated — chunk crossed `## B`:\n"
+          << ch.text;
+    }
+  }
+  EXPECT_TRUE(found_b_chunk) << "No chunk contained `## B`";
+}
+
+TEST(MarkdownChunkerTest, OverlapWalksForwardToSentenceStart) {
+  // Construct zh-TW input where chunk 0 contains a full sentence
+  // mid-body (with `。` in its interior, not at its end) — so the
+  // raw N-char tail lands mid-sentence, and walking forward should
+  // advance to the next `。`.
+  //
+  // Chunker trace at target=20, sep `\n\n` splits:
+  //   Piece 0: "超長第一句內容。超長第二句內容。" (16 chars)
+  //   Piece 1: "第三段。" (4 chars)
+  //   Merge: buf="超長第一句內容。超長第二句內容。" (16) — adding
+  //   Piece 1 with sep "\n\n" gives 16+2+4=22 > 20 → flush. Chunk
+  //   0 = "超長第一句內容。超長第二句內容。". Chunk 1 = "第三段。".
+  //
+  // Overlap pass (overlap=10, search=20):
+  //   Chunk 0 has 16 chars. Raw last-10-char tail starts at char 6
+  //   = byte 18 → tail begins mid-sentence at "容。超長第二句內容。".
+  //   Walk forward: first `。` at byte 21. boundary_start = 24.
+  //   Walked tail = "超長第二句內容。" (8 chars) — clean sentence
+  //   start.
+  //
+  // Assertion: chunk[1] must NOT contain "容。超" (raw-tail marker)
+  // — it must begin with the post-`。` "超長第二".
+  MarkdownChunker c({.target_chunk_chars = 20,
+                     .overlap_chars = 10,
+                     .respect_markdown_headers = false,
+                     .overlap_boundary_search_chars = 20});
+  std::string input = "超長第一句內容。超長第二句內容。\n\n第三段。";
+  auto chunks = c.Split(input);
+  ASSERT_GE(chunks.size(), 2u);
+
+  const std::string &second = chunks[1].text;
+  EXPECT_EQ(second.find("容。超"), std::string::npos)
+      << "Second chunk starts mid-sentence — walk did not advance past `。`:\n"
+      << second;
+  EXPECT_EQ(second.find("超長第二"), 0u)
+      << "Second chunk does not start at the post-`。` clean sentence:\n"
+      << second;
+}
+
+TEST(MarkdownChunkerTest, OverlapDoesNotCrossHeader) {
+  // Two sections. Section A's trailing sentences are exactly the
+  // text we'd expect overlap to grab. With header respect on, no
+  // chunk in section B may contain any of section A's content —
+  // not even in its overlap prefix.
+  MarkdownChunker c({.target_chunk_chars = 30,
+                     .overlap_chars = 20,
+                     .respect_markdown_headers = true,
+                     .overlap_boundary_search_chars = 0});
+  std::string input = "## A\n\nsection A unique marker AAAA.\n\n"
+                      "## B\n\nsection B unique marker BBBB.";
+  auto chunks = c.Split(input);
+  ASSERT_GE(chunks.size(), 2u);
+
+  for (const auto &ch : chunks) {
+    if (ch.text.find("BBBB") != std::string::npos) {
+      EXPECT_EQ(ch.text.find("AAAA"), std::string::npos)
+          << "Overlap crossed `## B` header:\n"
+          << ch.text;
+    }
+  }
+}
+
+TEST(MarkdownChunkerTest, RespectMarkdownHeadersFalseRestoresV1) {
+  // When the flag is off, headers are just text. Confirm the
+  // splitter merges across headers like before — this is the
+  // explicit escape hatch for plain-text corpora where `#` has no
+  // semantic meaning.
+  MarkdownChunker c({.target_chunk_chars = 200,
+                     .overlap_chars = 0,
+                     .respect_markdown_headers = false,
+                     .overlap_boundary_search_chars = 0});
+  std::string input = "## A\n\nshort body.\n\n## B\n\nanother short body.";
+  auto chunks = c.Split(input);
+  // Without segmentation, this whole input fits in one chunk
+  // (target=200, total < 60 chars) — so we get exactly one chunk.
+  // With segmentation, we'd get at least 3.
+  ASSERT_EQ(chunks.size(), 1u);
+  EXPECT_NE(chunks[0].text.find("## A"), std::string::npos);
+  EXPECT_NE(chunks[0].text.find("## B"), std::string::npos);
+}
+
+TEST(MarkdownChunkerCorpusTest, TaiwanCorpusNoChunkSpansTwoHeaders) {
+  // Regression for the 2026-04-21 LAN smoke finding: a chunk's text
+  // included "130公里...## 地理與氣候臺灣島的總..." — overlap from
+  // the "概覽" section bleeding across `## 地理與氣候` into the next
+  // section's content. With respect_markdown_headers=true, no chunk
+  // may contain more than one `##` header line.
+  const std::string path = ResolveTaiwanCorpusPath();
+  std::ifstream f(path);
+  ASSERT_TRUE(f.good()) << "Cannot open corpus: " << path;
+  std::ostringstream ss;
+  ss << f.rdbuf();
+  const std::string corpus = ss.str();
+
+  MarkdownChunker c; // default
+  auto chunks = c.Split(corpus);
+  ASSERT_GE(chunks.size(), 2u);
+
+  for (std::size_t i = 0; i < chunks.size(); ++i) {
+    const std::string &t = chunks[i].text;
+    std::size_t header_count = 0;
+    // Count occurrences of `\n## ` plus a starting `## ` if the
+    // chunk begins with a header line.
+    if (t.size() >= 3 && t.substr(0, 3) == "## ")
+      ++header_count;
+    std::size_t pos = 0;
+    while ((pos = t.find("\n## ", pos)) != std::string::npos) {
+      ++header_count;
+      ++pos;
+    }
+    EXPECT_LE(header_count, 1u)
+        << "Chunk " << i << " spans " << header_count
+        << " `## ` headers — overlap crossed a section boundary:\n"
+        << t;
+  }
 }
 
 TEST(MarkdownChunkerCorpusTest, ByteOffsetsAreNonDecreasing) {


### PR DESCRIPTION
## Summary

Fixes the chunker bug surfaced in the 2026-04-21 LAN smoke (Issue 2 in PR #66, explicitly deferred there to its own PR).

## The bug (from LAN smoke)

A chunk's text contained something like:

> `"...海峽最窄距離約130公里...\n\n## 地理與氣候臺灣島的總陸地面積..."`

Two things wrong:

1. Overlap prefix of one chunk pulled material **across** the `## 地理與氣候` header from the previous section.
2. The overlap tail was a raw last-80-char slice, so the prefix **started mid-sentence** ("...130公里...") instead of at a sentence boundary.

## Root cause

`MarkdownChunker::Split` treated `##` headers as just text that happens to sit between `\n\n` separators. `ApplyOverlap` then blindly copied the last N UTF-8 chars of chunk N to the front of chunk N+1 — no boundary awareness at all.

Concretely on `docs/rag/taiwan.md`:

- The 概覽 paragraph (~165 chars) merged with neighboring content including the `## 地理與氣候` header line up to target 450.
- The flush emitted one chunk ending at `"... ## 地理與氣候"` (header trailing).
- Overlap then grabbed the last 80 chars — which included the header — and prepended them to the next chunk (the 地理 body), rendering as the "地理與氣候臺灣島的總" run-on when displayed without the `\n\n`.

## The fix

Two orthogonal rules layered on top of the existing separator cascade. Neither touches the ADR-0019 §Decision.2 450/80 sizing contract or the separator priority list.

**1. Markdown-aware segmentation** — `Config::respect_markdown_headers` (default `true`)

Lines matching `^#+\s+` are HARD segment boundaries. `SplitRecursive` runs per segment; `ApplyOverlap` runs per segment; no chunk (including its overlap prefix) ever crosses a header. Header line joins the section BELOW it (its own content).

Set `false` to restore the v1 behavior — useful for plain-text corpora where `#` has no semantic meaning.

**2. Sentence-aware overlap walk** — `Config::overlap_boundary_search_chars` (default `40`)

After computing the raw last-N-char tail, walk forward up to this many UTF-8 code points looking for `。/！/？/\n`. If found, the overlap tail begins AFTER that mark, so the overlap prefix of chunk N+1 starts cleanly at a new sentence.

`，` is intentionally NOT a boundary — it's intra-sentence, so starting the prefix after `，` still strands the reader mid-thought.

Set `0` to disable the walk (v1 behavior).

## Tests

5 new cases + 1 updated existing:

- `HeaderIsHardSegmentBoundary` — chunk containing `## B` must not contain any of `## A`'s body.
- `OverlapWalksForwardToSentenceStart` — constructed zh-TW input where raw tail is mid-sentence; assert walked tail begins at post-`。` position.
- `OverlapDoesNotCrossHeader` — even with overlap set high, no `BBBB` chunk contains `AAAA` from the previous section.
- `RespectMarkdownHeadersFalseRestoresV1` — flag off → whole input merges into one chunk across headers.
- `TaiwanCorpusNoChunkSpansTwoHeaders` — regression guard on the real corpus: no chunk contains more than one `## ` header line.
- `OverlapPresentBetweenAdjacentChunks` updated from "cur starts with exactly the last 80 chars of prev" to "SOME non-empty suffix of prev is a prefix of cur" — the walk can shorten the tail below 80, so the exact length is no longer a stable invariant.

## Test plan

- [x] `bazel test //engine_cpp/tests/unit:chunker_test` — 17/17 PASSED (12 existing + 5 new)
- [x] `bazel test //engine_cpp/tests/integration:engine_seed_test` — PASSED (confirms seeder still works with new chunker output)
- [x] `bazel test //engine_cpp/tests/unit:all //engine_cpp/tests/integration:engine_seed_test` — 11/11 PASSED (no regression in retriever / embedder / etc.)
- [x] Pre-commit hooks pass (clang-format auto-fixed once)
- [ ] CI green
- [ ] **Re-seed Qdrant after merge**: `engine seed --corpus docs/rag/taiwan.md --target=local` (chunk content changes → content-hash UUIDs change → old points stale). Part of the LAN re-verify gate per `project_lan_reverify_gate` memory.
- [ ] **User LAN re-verify**: speak about Taiwan's geography; hint excerpts should start at a sentence/header boundary and stay within one `##` section.

## Testing escape hatch (CLAUDE.md Rule 2)

No automated "hint quality is better" test. That's an end-to-end human-perception judgment — the LAN re-verify drive is the acceptance gate (per `project_lan_reverify_gate` memory). What CI catches: structural invariants (no chunk spans two headers, overlap prefixes start at sentence boundaries). What only LAN catches: whether the cleaner chunks produce higher-quality hints at the embedder + retriever layer for real spoken queries.

## ADR alignment

ADR-0019 §Decision.2 amended in this PR with the two new rules — the 2026-04-15 ADR-0020 supersession note continues to hold (Python → engine-owned is unchanged; the chunking contract is the one ADR-0019 still owns).

## Out of scope

- A related pre-existing bug (chunker drops `。` when a flush fires right at a `。`-boundary piece transition) is NOT fixed here — neither observed in LAN smoke nor exacerbated by these changes. Noted in code trace for future cleanup.
- PR B (`download_models.sh` default flip) and PR C (`lan-smoke.sh` Qdrant supervisor) remain separate PRs per the demo-polish TODO list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)