### PR TITLE
fix(models): flip download_models.sh default to all non-PLACEHOLDER

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,9 +128,11 @@ yours.
 **Prerequisites** (one-time, ~5 min):
 
 ```bash
-# Embedder: bge-m3 Q4_K_M (438 MB). required=false in the manifest, so
-# download_models.sh's default run skips it — pass --model explicitly.
-./tools/scripts/download_models.sh --model bge-m3-q4km
+# Models: the default download_models.sh run fetches every pinned
+# (non-PLACEHOLDER) model, including bge-m3 Q4_K_M (438 MB) — which the
+# RAG path needs. If you already ran the Quick Start from the top of
+# this doc, this is a no-op.
+./tools/scripts/download_models.sh
 
 # Qdrant: follow docs/runbooks/qdrant-local-setup.md to get a server
 # listening on localhost:6334. Keep that terminal open.

--- a/README.md
+++ b/README.md
@@ -280,8 +280,10 @@ for the specific known gaps before you start.
 git clone https://github.com/BinHsu/aegis-core.git
 cd aegis-core
 
-# One-time: fetch the whisper model (~75 MB, SHA-256-verified)
-./tools/scripts/download_models.sh --all
+# One-time: fetch every pinned model (~75 MB whisper + 438 MB bge-m3,
+# all SHA-256-verified). Default covers every non-PLACEHOLDER entry;
+# pass --required-only to skip the optional bge-m3 embedder.
+./tools/scripts/download_models.sh
 
 # Run everything — engine + gateway, one command
 ./tools/bazelisk/bazelisk run //:app_local

--- a/apps/staging/README.md
+++ b/apps/staging/README.md
@@ -17,7 +17,7 @@ The contract is documented in
 If you cloned this repo to try the **single-machine experience** —
 
 ```bash
-./tools/scripts/download_models.sh --all
+./tools/scripts/download_models.sh
 ./tools/bazelisk/bazelisk run //:app_local
 ```
 

--- a/models/README.md
+++ b/models/README.md
@@ -56,11 +56,16 @@ model's hash (threat-model.md threat T6).
 ## Download Script
 
 ```bash
-# Download all required models (verifies SHA-256 after download)
+# Download every pinned model — whisper-tiny + bge-m3 (verifies
+# SHA-256 after each download). Default since 2026-04-22.
 ./tools/scripts/download_models.sh
 
+# Lightweight mode — only models that are required=true at engine
+# startup. Skips bge-m3; suitable for CI / minimal installs.
+./tools/scripts/download_models.sh --required-only
+
 # Download a specific model by ID
-./tools/scripts/download_models.sh --model=whisper-large-v3-turbo-q4
+./tools/scripts/download_models.sh --model whisper-large-v3-turbo-q4
 
 # Verify existing models without downloading
 ./tools/scripts/download_models.sh --verify-only

--- a/models/manifest.json
+++ b/models/manifest.json
@@ -77,7 +77,7 @@
       "upstream_model_license_url": "https://huggingface.co/BAAI/bge-m3",
       "required": false,
       "phase": 3,
-      "notes": "~700 MB RAM estimate (conservative; file is 438 MB, runtime adds tokenizer + activations). Currently required=false: only loaded by the opt-in `engine seed` subcommand (`engine_cpp/cmd/engine/seed.cc` via GGMLEmbedder::Create) — not loaded at engine startup. Promote back to required=true when engine main wires GGMLEmbedder eagerly (comment at main.cc:90 reserves this for 'Phase 3b'; not yet implemented). Embedding dimension: 1024 (bge-m3 dense). Max sequence length: 8192 tokens. Feeds ModelBudget per ADR-0010 revision (Phase 3b Slice 1)."
+      "notes": "~700 MB RAM estimate (conservative; file is 438 MB, runtime adds tokenizer + activations). Currently required=false because startup is graceful-degrade: `engine_cpp/cmd/engine/main.cc` best-effort loads bge-m3 for the live-path retriever (Session::Run wires a Retriever only when both the embedder and a Qdrant client come up), and the opt-in `engine seed` subcommand also uses the same GGMLEmbedder to build the corpus index. Either caller missing ⇒ retriever stays nullptr and sessions degrade to transcript-only — no hard boot failure. Promote to required=true when bge-m3 joins the baseline ModelBudget set (i.e. no graceful-degrade path left). Embedding dimension: 1024 (bge-m3 dense). Max sequence length: 8192 tokens. Feeds ModelBudget per ADR-0010 revision (Phase 3b Slice 1)."
     },
     {
       "id": "llama-3-8b-instruct-q4km",

--- a/tools/scripts/download_models.sh
+++ b/tools/scripts/download_models.sh
@@ -14,10 +14,19 @@
 # it is moved (not re-downloaded) to its new CAS path.
 #
 # Usage:
-#   ./tools/scripts/download_models.sh                 # all required=true models
+#   ./tools/scripts/download_models.sh                 # all non-PLACEHOLDER models (default)
+#   ./tools/scripts/download_models.sh --required-only # only required=true entries (lightweight)
 #   ./tools/scripts/download_models.sh --model <id>    # one model by id
 #   ./tools/scripts/download_models.sh --verify-only   # no download, just check
-#   ./tools/scripts/download_models.sh --all           # include optional (required=false) models
+#   ./tools/scripts/download_models.sh --all           # alias for the default (back-compat)
+#
+# Default changed on 2026-04-22 from `--required` to "all non-PLACEHOLDER":
+# `required=true` governs engine-startup MUST-LOAD behavior, not distribution.
+# When download defaults followed `required`, fresh clones silently skipped
+# bge-m3 (438 MB, `required=false`) and the LAN demo's hint panel stayed
+# empty — "why is the hint not firing?" was a recurring support cost. The
+# new default ships every pinned model; `--required-only` remains as the
+# opt-in lightweight mode for CI / minimal installs.
 #
 # The engine CAS preflight walker (engine_cpp/src/models/manifest_loader)
 # verifies SHA-256 at startup; this script is the pre-flight that saves
@@ -30,17 +39,18 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 MODELS_DIR="$REPO_ROOT/models"
 MANIFEST="$MODELS_DIR/manifest.json"
 
-MODE="required"    # required | all | one | verify
+MODE="all"    # all | required | one
 ONLY_ID=""
 VERIFY_ONLY=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --model)        MODE="one"; ONLY_ID="${2:-}"; shift 2 ;;
-    --all)          MODE="all"; shift ;;
-    --verify-only)  VERIFY_ONLY=1; shift ;;
+    --model)          MODE="one"; ONLY_ID="${2:-}"; shift 2 ;;
+    --all)            MODE="all"; shift ;;
+    --required-only)  MODE="required"; shift ;;
+    --verify-only)    VERIFY_ONLY=1; shift ;;
     --help|-h)
-      sed -n '3,24p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '3,31p' "$0" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac

--- a/tools/scripts/lan-smoke.sh
+++ b/tools/scripts/lan-smoke.sh
@@ -9,7 +9,10 @@
 #
 # Sequence:
 #
-#   1. bge-m3 embedder present (via download_models.sh --model)
+#   1. bge-m3 embedder present (safety net — verifies via
+#      download_models.sh --verify-only; fetches with --model only if
+#      still missing. Expected no-op when the user ran the default
+#      download_models.sh at clone time per README §Quick Start)
 #   2. Qdrant supervisor:
 #        - If :6333 already healthy → treat as user-started external
 #          instance; reuse + DO NOT manage its lifecycle.
@@ -113,7 +116,22 @@ trap cleanup_qdrant EXIT INT TERM
 # --- Step 1: embedder -------------------------------------------------------
 
 say "step 1/3 — bge-m3 embedder"
-"$REPO_ROOT/tools/scripts/download_models.sh" --model bge-m3-q4km
+# Safety net: README Quick Start's default `download_models.sh` run
+# already fetched bge-m3 (since 2026-04-22 the default covers every
+# non-PLACEHOLDER model). Verify silently; only fall through to a real
+# download if the CAS file is actually missing. Capture output via a
+# variable to sidestep pipefail interactions with a non-matching
+# `grep -q` in an `if` condition.
+if ! verify_output=$("$REPO_ROOT/tools/scripts/download_models.sh" --verify-only 2>&1); then
+  printf '%s\n' "$verify_output" >&2
+  die "download_models.sh --verify-only failed (see above)"
+fi
+if printf '%s\n' "$verify_output" | grep -q "^\[miss\] bge-m3-q4km"; then
+  say "  bge-m3 missing — fetching (438 MB, one-time)"
+  "$REPO_ROOT/tools/scripts/download_models.sh" --model bge-m3-q4km
+else
+  say "  bge-m3 already present — skip"
+fi
 
 # --- Step 2: Qdrant supervisor ---------------------------------------------
 


### PR DESCRIPTION
## Summary

Fresh clones silently skipped bge-m3 — the LAN demo's hint panel stayed empty until the user figured out they needed `--model bge-m3-q4km`. Flip the default so bge-m3 (and any future pinned model) ships by default.

## Root cause

`download_models.sh`'s default mode was `required` — pulls only `required=true` entries. Manifest has bge-m3 at `required=false`, so it got skipped. But `required=true` is an ENGINE-STARTUP contract ("boot fails without this model"), not a DISTRIBUTION contract ("ship this when a user clones the repo"). Two different properties, same flag, silent pain.

Before: fresh clone → run `download_models.sh` → get whisper-tiny only → run `lan-smoke.sh` → bge-m3 fetches late → confusion about why prerequisites weren't done up front.

After: fresh clone → run `download_models.sh` → get whisper-tiny + bge-m3 → `lan-smoke.sh` verify step is a silent no-op.

## Changes

- **`download_models.sh`** — default MODE flips from `required` to `all`. `--all` kept as back-compat alias. New `--required-only` flag for lightweight mode (CI / minimal installs).
- **`models/manifest.json`** — bge-m3 `notes` rewritten. Old text said "only loaded by the opt-in `engine seed` subcommand, not loaded at engine startup" — but `engine main.cc:183-192` has best-effort-loaded bge-m3 for the live retriever since Phase 3c Slice 8 (2026-04-21). The `required=false` label remains accurate (startup gracefully degrades without it), the narrative around it was stale.
- **`tools/scripts/lan-smoke.sh`** — step 1 is now a safety net. `--verify-only` first, real download only if the CAS file is missing. Output captured via variable to sidestep `set -euo pipefail` interactions with a non-matching `grep -q` in an `if` condition.
- **`CONTRIBUTING.md` §LAN smoke**, **`README.md` §Quick Start**, **`apps/staging/README.md`**, **`models/README.md`** — reworded to reflect the new default. Also fixes a stealth bug in the old `models/README.md` example (`--model=<id>` — the arg parser only accepts the space-separated `--model <id>` form).

## Test plan

- [x] `./tools/scripts/download_models.sh --verify-only` — walks whisper-tiny + bge-m3, skips 3 PLACEHOLDERS.
- [x] `./tools/scripts/download_models.sh --required-only --verify-only` — walks whisper-tiny only.
- [x] `./tools/scripts/download_models.sh --all --verify-only` — matches the new default (back-compat).
- [x] `./tools/scripts/download_models.sh --model=whisper-tiny-en --verify-only` — errors "Unknown argument" (confirms the old `=` form never worked; models/README.md docs fix isn't regressing anything).
- [x] `bash -n tools/scripts/lan-smoke.sh` — syntax ok.
- [x] `lan-smoke.sh` step 1 runs clean when bge-m3 is already present (skip path).
- [x] Pre-commit hooks pass (prettier + json check).
- [ ] CI green.

## Out of scope

- **PR #67** (chunker markdown-aware rework) — independent PR, currently open.
- **Next PR** — `lan-smoke.sh` Qdrant supervisor (auto-download `./qdrant` if missing, trap-cleanup). That's the ergonomics half of the re-verify gate per `project_lan_reverify_gate` memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)