### PR TITLE
feat(lan-smoke): Qdrant supervisor — auto-download + trap cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,15 +213,17 @@ coverage/
 # and its data dir live inside the repo per CLAUDE.md Rule 6 but are
 # per-machine state, never committed. `config` and `LICENSE_BSL_4.0.txt`
 # ship inside Qdrant's release tarball and land at the repo root on
-# extraction. `storage/` + `.qdrant-initialized` are created when
-# Qdrant runs without `--config-path` (its default storage location
-# is ./storage/), so guard those too.
+# extraction. `storage/`, `snapshots/`, and `.qdrant-initialized` are
+# created when Qdrant runs without `--config-path` (its default
+# storage + snapshot paths are ./storage/ + ./snapshots/), so guard
+# those too.
 /qdrant
 /.qdrant-data/
 /.qdrant-initialized
 /config
 /LICENSE_BSL_4.0.txt
 /storage/
+/snapshots/
 
 # --- Author-personal files (NOT for repo consumers) ---------------------
 # Private interview-prep reference maintained by the author. Contains

--- a/tools/scripts/lan-smoke.sh
+++ b/tools/scripts/lan-smoke.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Aegis Core — LAN smoke prerequisites.
+# Aegis Core — LAN smoke prerequisites + Qdrant supervisor.
 #
 # Checks + prepares everything the engine's RAG path needs before you run
 # the full `bazel run //:app_local --with-frontend` demo. The only thing
@@ -10,9 +10,19 @@
 # Sequence:
 #
 #   1. bge-m3 embedder present (via download_models.sh --model)
-#   2. Qdrant reachable on :6334 (fail-fast if not; see runbook)
+#   2. Qdrant supervisor:
+#        - If :6333 already healthy → treat as user-started external
+#          instance; reuse + DO NOT manage its lifecycle.
+#        - Else → fetch `./qdrant` if missing (4 OS/arch matrix),
+#          start in background, wait for :6333/healthz, register
+#          `trap EXIT INT TERM` that kills ONLY our own PID.
 #   3. Taiwan corpus seeded into the local Qdrant collection
-#   4. Print the final `bazel run //:app_local` command to copy-paste
+#   4. Print the final `bazel run //:app_local` command. If we started
+#      Qdrant ourselves, the script then BLOCKS (wait on the qdrant
+#      PID) so the user can run app_local in a second terminal;
+#      Ctrl-C returns control and the trap cleans up. If Qdrant was
+#      already running, the script exits immediately (preserves the
+#      old one-shot UX for users who manage their own instance).
 #
 # Idempotent — every step short-circuits when already satisfied. See
 # CONTRIBUTING.md §LAN smoke for the full human-in-the-loop flow.
@@ -24,7 +34,14 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 QDRANT_REST_PORT="${QDRANT_REST_PORT:-6333}"
 QDRANT_GRPC_PORT="${QDRANT_GRPC_PORT:-6334}"
+QDRANT_VERSION="${QDRANT_VERSION:-v1.17.1}"
+QDRANT_RELEASE_BASE="https://github.com/qdrant/qdrant/releases/download/$QDRANT_VERSION"
 CORPUS="$REPO_ROOT/docs/rag/taiwan.md"
+
+# PID of the qdrant instance THIS SCRIPT started. Empty when we're
+# reusing a user-started external instance; the trap must not touch
+# that PID space.
+LAN_SMOKE_QDRANT_PID=""
 
 say() {
   printf '\033[1;34m[lan-smoke]\033[0m %s\n' "$*"
@@ -35,32 +52,89 @@ die() {
   exit 1
 }
 
+# Return the tar.gz basename for the host's OS/arch, or fail. Keep
+# this table in sync with https://github.com/qdrant/qdrant/releases —
+# Qdrant ships 4 prebuilt binary archives covering the common LAN
+# demo hardware (Apple Silicon, Intel Mac, x86 Linux, ARM Linux).
+qdrant_tarball_for_host() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "$os/$arch" in
+    Darwin/arm64)              echo "qdrant-aarch64-apple-darwin.tar.gz" ;;
+    Darwin/x86_64)             echo "qdrant-x86_64-apple-darwin.tar.gz" ;;
+    Linux/x86_64)              echo "qdrant-x86_64-unknown-linux-gnu.tar.gz" ;;
+    Linux/aarch64|Linux/arm64) echo "qdrant-aarch64-unknown-linux-gnu.tar.gz" ;;
+    *) return 1 ;;
+  esac
+}
+
+ensure_qdrant_binary() {
+  if [[ -x "$REPO_ROOT/qdrant" ]]; then
+    return 0
+  fi
+  local tarball
+  tarball="$(qdrant_tarball_for_host)" || \
+    die "unsupported OS/arch ($(uname -s) $(uname -m)); install qdrant manually per docs/runbooks/qdrant-local-setup.md"
+  say "  downloading Qdrant $QDRANT_VERSION ($tarball) — one-time, ~20 MB"
+  # Pinned to a concrete release tag + HTTPS; no SHA-256 verification
+  # yet (TODO: pin tarball digests when the ADR-0026-style third-party-
+  # binary CAS pattern lands). Matches the posture of the runbook
+  # snippet we're replacing, no regression.
+  ( cd "$REPO_ROOT" && curl -fsSL "$QDRANT_RELEASE_BASE/$tarball" | tar xz )
+  [[ -x "$REPO_ROOT/qdrant" ]] || \
+    die "Qdrant tarball extracted but ./qdrant not found — unexpected layout"
+}
+
+wait_for_qdrant_ready() {
+  local timeout_s=30 elapsed=0
+  while (( elapsed < timeout_s )); do
+    if curl -fsS "http://localhost:$QDRANT_REST_PORT/healthz" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  return 1
+}
+
+cleanup_qdrant() {
+  # Trap handler — only kills the PID we started, NEVER user-external
+  # instances (LAN_SMOKE_QDRANT_PID stays empty in that branch).
+  if [[ -n "$LAN_SMOKE_QDRANT_PID" ]] \
+       && kill -0 "$LAN_SMOKE_QDRANT_PID" 2>/dev/null; then
+    say "  stopping supervised qdrant (pid $LAN_SMOKE_QDRANT_PID)"
+    kill "$LAN_SMOKE_QDRANT_PID" 2>/dev/null || true
+    wait "$LAN_SMOKE_QDRANT_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup_qdrant EXIT INT TERM
+
 # --- Step 1: embedder -------------------------------------------------------
 
 say "step 1/3 — bge-m3 embedder"
 "$REPO_ROOT/tools/scripts/download_models.sh" --model bge-m3-q4km
 
-# --- Step 2: Qdrant health probe -------------------------------------------
+# --- Step 2: Qdrant supervisor ---------------------------------------------
 
 say "step 2/3 — Qdrant on :$QDRANT_GRPC_PORT"
 if curl -fsS "http://localhost:$QDRANT_REST_PORT/healthz" >/dev/null 2>&1; then
-  say "  qdrant REST :$QDRANT_REST_PORT → ok"
+  say "  qdrant already running (external) → reuse, will NOT manage lifecycle"
 else
-  cat >&2 <<EOF
-[lan-smoke] qdrant not reachable on localhost:$QDRANT_REST_PORT (REST probe).
-
-  Start it per docs/runbooks/qdrant-local-setup.md. Shortest path on
-  Apple Silicon:
-
-    cd $REPO_ROOT
-    curl -sL \\
-      https://github.com/qdrant/qdrant/releases/download/v1.17.1/qdrant-aarch64-apple-darwin.tar.gz \\
-      | tar xz
-    ./qdrant --disable-telemetry >/dev/null 2>&1 &
-
-  Then re-run this script.
-EOF
-  exit 1
+  say "  qdrant not running — supervising a local instance"
+  ensure_qdrant_binary
+  # Start in a subshell so the `cd` is scoped and the qdrant data dir
+  # lands at REPO_ROOT/.qdrant-data (gitignored). `exec` replaces the
+  # subshell with qdrant itself so `$!` captures qdrant's real PID —
+  # without `exec`, `$!` would point at the short-lived subshell
+  # parent and killing it would leave qdrant orphaned under init.
+  # Redirect stdout/err to /dev/null — qdrant is chatty on startup.
+  ( cd "$REPO_ROOT" && exec ./qdrant --disable-telemetry >/dev/null 2>&1 ) &
+  LAN_SMOKE_QDRANT_PID=$!
+  if ! wait_for_qdrant_ready; then
+    die "qdrant did not become ready on :$QDRANT_REST_PORT within 30s (pid $LAN_SMOKE_QDRANT_PID)"
+  fi
+  say "  qdrant up (pid $LAN_SMOKE_QDRANT_PID), REST :$QDRANT_REST_PORT → ok"
 fi
 
 # --- Step 3: seed corpus ---------------------------------------------------
@@ -80,7 +154,7 @@ AEGIS_MODEL_PATH="$REPO_ROOT/models" \
 
 cat <<EOF
 
-\033[1;32m[lan-smoke] prerequisites ready.\033[0m
+$(printf '\033[1;32m')[lan-smoke] prerequisites ready.$(printf '\033[0m')
 
 Start the full stack in a separate terminal:
 
@@ -95,3 +169,16 @@ Then:
   4. Speak into the mic
 
 EOF
+
+if [[ -n "$LAN_SMOKE_QDRANT_PID" ]]; then
+  cat <<EOF
+$(printf '\033[1;33m')[lan-smoke] Qdrant is supervised by this script (pid $LAN_SMOKE_QDRANT_PID).$(printf '\033[0m')
+Leave this terminal open while you run app_local. Press Ctrl-C here
+when you're done with the demo — Qdrant will be stopped cleanly.
+(If you'd rather manage Qdrant yourself, start it before running
+this script and we'll detect + reuse it.)
+
+EOF
+  # Block until qdrant exits or user signals. Trap handles cleanup.
+  wait "$LAN_SMOKE_QDRANT_PID" || true
+fi


### PR DESCRIPTION
## Summary

The LAN smoke flow is now one command. Before: open a second terminal, curl the Qdrant tarball, start the binary, switch back, run `lan-smoke.sh`. After: run `lan-smoke.sh`; it supervises Qdrant end-to-end.

## Changes

**`tools/scripts/lan-smoke.sh`** — step 2 becomes a supervisor:

- Probe `:6333/healthz`. If healthy, treat as user-managed external instance — do NOT manage its lifecycle. Script exits immediately after step 3 (preserves old one-shot UX for users who run their own Qdrant).
- If no instance is running:
  - Fetch `./qdrant` for the host OS/arch from pinned Qdrant release `v1.17.1` if the binary is missing. 4 prebuilt archives supported: Darwin arm64 / x86_64, Linux x86_64 / aarch64.
  - Start `./qdrant --disable-telemetry` in a subshell via **`exec`** — critical: without `exec`, `$!` captures the short-lived subshell parent, not Qdrant's real PID, and the trap would miss the right process.
  - Wait up to 30 s for `:6333/healthz`; fail fast if not ready.
  - Register `trap cleanup_qdrant EXIT INT TERM` that kills ONLY our own `LAN_SMOKE_QDRANT_PID`. The external-instance branch never sets that variable, so user-managed Qdrants are untouched.
- Post-prereq, when the script started Qdrant, it BLOCKS on `wait $qdrant_pid` so `bazel run //:app_local` in a second terminal can use it. User Ctrl-Cs the supervisor when done; trap fires; clean exit.

**`.gitignore`** — add `/snapshots/`. Pre-existing gap: Qdrant creates `storage/` + `snapshots/` on first run; `storage/` was gitignored but `snapshots/` was not. Fixing here while in the Qdrant-local-state block context.

## Test plan

- [x] `bash -n tools/scripts/lan-smoke.sh` — syntax clean.
- [x] Dry run with no Qdrant: script reports "qdrant not running — supervising"; reported PID matches `pgrep ./qdrant` (exec fix verified); step 3 seed completes; script enters `wait` block.
- [x] SIGTERM the supervised script: trap fires; both the bash process and its child `./qdrant` cleanly gone; no stale `storage/` / `.qdrant-initialized` leaked.
- [x] Pre-commit hooks pass.
- [ ] CI green.
- [ ] **User re-verify (LAN)**: real-tty Ctrl-C behaviour — part of the `project_lan_reverify_gate` acceptance drive.

## Testing escape hatch (CLAUDE.md Rule 2)

No automated test for "Ctrl-C in an interactive tty cleans up the supervised Qdrant". In the bash-tool harness, the script runs non-interactively and tty signal delivery differs. `SIGTERM` clean-up is verified and is the functionally equivalent path; real-tty `SIGINT` via Ctrl-C goes to the process group, so Qdrant receives it directly even without the trap — the trap is a safety net for the common case, not the load-bearing mechanism. LAN re-verify per memory `project_lan_reverify_gate` is the acceptance gate.

## Depends on / stacks with

- **PR #68** (`download_models.sh` default flip) — independent file (different section of `lan-smoke.sh`; my edits are step 2, #68 is step 1). If #68 merges first, this branch will cleanly fast-forward. If this merges first, #68 will cleanly rebase.
- **PR #67** (chunker markdown-aware) — already MERGED to main.

## Completes the demo-polish quartet

With this merged: 1-4 of the TODO list are done (1: PR #66 merged, 2: PR #67 merged, 3: PR #68 open, 4: this). Per the `project_lan_reverify_gate` memory, next session opens with a prompt to re-drive LAN smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)