### PR TITLE
feat(session): bump kLiveWindowSeconds from 3 to 5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,10 +156,9 @@ yours.
    derived from the corpus filename by `DeriveCollectionName()` in
    `engine_cpp/cmd/engine/seed.cc`.
 3. Scan the viewer QR with a phone on the same LAN.
-4. Speak into the mic. Every 3 s window produces a transcript segment
-   and triggers a RAG retrieval; hints fire on every window today (no
-   question gate, no score threshold) — documented in `ROADMAP.md`
-   Phase 4c as a UX-noise item, not a correctness bug.
+4. Speak into the mic. Every 5 s window produces a transcript segment
+   and triggers a RAG retrieval; hints fire on every window gated by
+   `min_score=0.42` and consecutive-same-topic dedupe (PR #66).
 
 **If `QDRANT_URL` is unset** when you run `app_local`, the engine logs
 `QDRANT_URL unset (RAG hints disabled)` and falls through to

--- a/engine_cpp/src/rag/retriever.cc
+++ b/engine_cpp/src/rag/retriever.cc
@@ -118,9 +118,9 @@ Retriever::Retrieve(std::string_view transcript_text) {
   }
 
   // Consecutive-same-topic dedupe. When a speaker stays on one topic
-  // across multiple 3 s flush windows the top match is usually the
-  // same chunk; re-emitting it every window spams the viewer with
-  // an identical suggestion. Suppress when the top point id matches
+  // across multiple flush windows the top match is usually the same
+  // chunk; re-emitting it every window spams the viewer with an
+  // identical suggestion. Suppress when the top point id matches
   // the last emission; let A → B → A through (intentional topic
   // return). Empty last_top_point_id_ (first call) always passes.
   if (top.id == last_top_point_id_) {

--- a/engine_cpp/src/rag/retriever.h
+++ b/engine_cpp/src/rag/retriever.h
@@ -56,7 +56,7 @@ public:
     // Minimum cosine-similarity score for a hint to be emitted.
     // Qdrant's top-K search always returns K results when the
     // collection has ≥ K points, regardless of how far off-topic the
-    // query is — without this threshold every 3 s transcript window
+    // query is — without this threshold every transcript window
     // fires a hint even when the speaker says "um, let me think" and
     // the viewer UI overwrites with garbage. 0.42 is conservative
     // for bge-m3 multilingual (zh-TW tokens are semantic-dense; the
@@ -113,7 +113,7 @@ private:
   // as a hint. Consecutive Retrieve() calls whose top match is the
   // SAME point id return NotFound — a speaker staying on the same
   // topic should not flood the viewer with the same corpus chunk
-  // every 3 s. Cleared back to the new top whenever a different
+  // every window. Cleared back to the new top whenever a different
   // point wins, so A → B → A is three distinct emissions (topic
   // changed away and back).
   std::string last_top_point_id_;

--- a/engine_cpp/src/session/session.cc
+++ b/engine_cpp/src/session/session.cc
@@ -29,18 +29,27 @@ constexpr std::size_t kDefaultReservationBytes = 200ULL * 1024 * 1024;
 
 // Live-transcribe window size (MVP).
 //
-// 3 seconds @ 16 kHz mono = 48000 samples. Trade-off summary:
+// 5 seconds @ 16 kHz mono = 80 000 samples. Trade-off summary:
 //   - Smaller window → lower latency to first segment, worse whisper
-//     accuracy (whisper's encoder was trained for ~30 s windows).
+//     accuracy (whisper's encoder was trained for ~30 s windows),
+//     more mid-sentence cuts in the emitted transcript.
 //   - Larger window → better accuracy, higher first-segment latency,
-//     higher per-session peak memory.
-// 3 s is the cheapest "live" cadence that still produces usable
-// transcription on tiny.en. No overlap is kept for MVP — words may
-// cut at window boundaries; VAD-based boundary selection is Phase 2+.
-// Final-flush at stream end (below) emits the remaining < window
-// sub-window so no audio is lost on EndMeeting.
+//     higher per-session peak memory, more context per transcript
+//     segment (fewer "1-second fragments" on the viewer).
+// Bumped from 3 → 5 s on 2026-04-22 after a LAN smoke drive exposed
+// the short-segment noise: at 3 s, speech routinely cut mid-phrase
+// (e.g. "臺灣是一個位於" | "東亞的島嶼"), and each segment felt
+// unfinished. 5 s restores enough context per segment for a natural
+// "cadence-of-reading" feel at the cost of +2 s to first hint.
+// Still cheap enough to keep "live" expectations intact; VAD-based
+// boundary selection (which decouples segment length from window
+// size entirely) is still Phase 2+.
+// No overlap is kept for MVP — words may still cut at window
+// boundaries, just less often. Final-flush at stream end (below)
+// emits the remaining < window sub-window so no audio is lost on
+// EndMeeting.
 constexpr std::size_t kSampleRateHz = 16000;
-constexpr std::size_t kLiveWindowSeconds = 3;
+constexpr std::size_t kLiveWindowSeconds = 5;
 constexpr std::size_t kLiveWindowSamples = kLiveWindowSeconds * kSampleRateHz;
 
 enum class State {

--- a/engine_cpp/tests/integration/stream_transcribe_test.cc
+++ b/engine_cpp/tests/integration/stream_transcribe_test.cc
@@ -266,9 +266,12 @@ TEST(StreamTranscribeTest, LiveWindowEmitsMidStream) {
   auto samples_or = audio::ReadWav16kMono(wav_path);
   ASSERT_TRUE(samples_or.ok()) << samples_or.status();
   const std::vector<float> &samples = *samples_or;
-  // Require enough audio to span at least two 3-second windows.
-  ASSERT_GE(samples.size(), static_cast<std::size_t>(6 * 16000))
-      << "fixture too short for multi-window regression; need ≥6s, got "
+  // Require enough audio to span at least two live windows (session.cc
+  // kLiveWindowSeconds — 5 as of 2026-04-22, so ≥ 10 s of PCM
+  // guarantees ≥ 2 full flushes before final-flush). jfk.wav ships
+  // ~11 s, comfortably above the bar.
+  ASSERT_GE(samples.size(), static_cast<std::size_t>(10 * 16000))
+      << "fixture too short for multi-window regression; need ≥10s, got "
       << (samples.size() / 16000) << "s";
   const std::string int16_le = FloatsToInt16LE(samples);
 
@@ -301,9 +304,9 @@ TEST(StreamTranscribeTest, LiveWindowEmitsMidStream) {
   }
 
   // Chunk strategy: split PCM into ~32 KB PcmChunks (same as
-  // JfkEndToEnd). With 6+ seconds of audio at 32 KB per chunk
-  // (= 16384 samples = ~1.02 s), we feed at least 6 chunks —
-  // which triggers at least 2 window flushes at 3-second boundaries.
+  // JfkEndToEnd). With 10+ seconds of audio at 32 KB per chunk
+  // (= 16384 samples = ~1.02 s), we feed at least 10 chunks —
+  // which triggers at least 2 window flushes at 5-second boundaries.
   constexpr std::size_t kChunkBytes = 32 * 1024;
   std::uint64_t chunk_id = 0;
   for (std::size_t off = 0; off < int16_le.size(); off += kChunkBytes) {

--- a/engine_cpp/tests/unit/retriever_test.cc
+++ b/engine_cpp/tests/unit/retriever_test.cc
@@ -177,7 +177,7 @@ TEST(RetrieverTest, ConsecutiveSameTopPointIsDedupedToNotFound) {
   FakeEmbedder e;
   FakeVectorSearcher s;
   // Same top point id on both calls — simulates a speaker staying on
-  // one topic across two 3 s flush windows.
+  // one topic across two flush windows.
   s.results_ = {
       MakeResult("uuid-same", 0.9f, "Taiwan climate is subtropical.", "doc.md",
                  "0"),


### PR DESCRIPTION
## Summary

LAN smoke re-verify exposed transcript segments felt choppy — 3-second windows cut speech mid-phrase ("臺灣是一個位於" | "東亞的島嶼"), with each segment too fragmentary to track. Bump `kLiveWindowSeconds` from 3 → 5 so each segment carries more context and whisper has more audio to work with (whisper's encoder was trained on ~30 s windows — closer is better).

Trade-off:
- **Cost**: first-segment latency +2 s (still sub-10 s full path voice → viewer).
- **Gain**: +66 % audio per whisper call → noticeably better accuracy, fewer mid-word cuts, each segment carries a full thought instead of a fragment.

## Changes

- **`engine_cpp/src/session/session.cc:43`** — constant flip; design-note comment at lines 30-42 expanded with trade-off reasoning + 2026-04-22 bump rationale.
- **`engine_cpp/tests/integration/stream_transcribe_test.cc`** — `ASSERT_GE` on fixture duration raised from `6 * 16000` → `10 * 16000` samples so the "spans ≥ 2 full windows" intent holds at 5 s width. jfk.wav ~11 s, well above the new bar.
- **`engine_cpp/src/rag/retriever.{cc,h}`, `retriever_test.cc`** — comment references to "every 3 s flush windows" softened to "flush windows" / "every window" (no numeric hard-code so future tuning doesn't drift the comments).
- **`CONTRIBUTING.md:159`** — "Every 5 s window" in the LAN smoke drive section (also tightened the hint-gate narrative to reflect PR #66 `min_score` + dedupe, dropping the outdated "no gate" language).

## Not touched

- **`docs/incidents.md:1449`** — Incident 14 postmortem quotes "3 s window" as it was at that point in time. Postmortems are frozen history (CLAUDE.md Rule 7); retroactive edits would lie about what happened.

## Test plan

- [x] `bazel test //engine_cpp/tests/...` — 15/15 PASSED.
- [x] `stream_transcribe_test` specifically — passes at new 10 s minimum. Emits multiple segments across the 11 s jfk fixture.
- [x] Pre-commit hooks pass.
- [ ] CI green.
- [ ] **User LAN re-verify**: segments carry 3-5 seconds of spoken content each, with fewer mid-word cuts. First-segment time should stay under ~8 s from speaking start.

## Stacks with

- **PR #71** — strip leading `##` from hint suggestion (merged independently).
- **PR #73** — viewer UI stitches transcript segments until sentence-end punctuation (incoming; orthogonal — this PR widens the engine's window, #73 smooths the UI-side rendering regardless of window size).

## What's still Phase 2+

VAD-based boundary selection — decouples segment length from window size entirely, emits segments at actual speech pauses. This PR just picks a better fixed window; VAD is still future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)