### PR TITLE
fix(host-ui): drop 4 placeholder RAG corpora from the dropdown

### DIFF
--- a/frontend_web/src/pages/Host/HostPage.tsx
+++ b/frontend_web/src/pages/Host/HostPage.tsx
@@ -91,23 +91,21 @@ const ALL_MODES: { readonly value: CaptureMode; readonly label: string }[] = [
 // plenty of meetings are better served by staff providing hints
 // manually than by a mediocre retrieval hit.
 //
-// The remaining entries are curated presets. A live system will
-// replace this with a per-tenant ListCorpora RPC once the query path
-// lands (Phase 4+); until then, the list is authored here and must be
-// kept in sync with what `engine seed` has actually populated in the
-// target Qdrant. `aegis_taiwan` is Slice 6's seeded corpus; the
-// `demo-rag-*` entries are placeholders for future demo content.
+// The list is authored here and must stay in sync with what `engine
+// seed` has actually populated in the target Qdrant — only
+// `aegis_taiwan` ships today (seeded from `docs/rag/taiwan.md`).
+// A live multi-tenant system replaces this with a per-tenant
+// `ListCorpora` RPC once the query path lands (Phase 4+); until
+// then, offering collections that don't exist upstream is a UX lie
+// — CreateMeeting would silently bind to a missing `rag_id` and the
+// retriever would log `no matches in '<missing>'` every window.
 //
 // The `value` is what the Gateway's CreateMeeting RPC sees in the
 // `rag_id` proto field; empty string means "no RAG binding". The
 // `label` is the human-friendly dropdown text.
 const RAG_CORPORA: { readonly value: string; readonly label: string }[] = [
   { value: "", label: "(No corpus — staff provides hints manually)" },
-  { value: "aegis_taiwan", label: "Taiwan reference (Slice 6 seeded)" },
-  { value: "demo-rag-general", label: "General demo corpus" },
-  { value: "demo-rag-engineering", label: "Engineering knowledge base" },
-  { value: "demo-rag-sales", label: "Sales deck library" },
-  { value: "demo-rag-support", label: "Customer support knowledge" },
+  { value: "aegis_taiwan", label: "Taiwan (zh-TW Wikipedia demo)" },
 ];
 const DEFAULT_RAG_ID = RAG_CORPORA[0]!.value; // "" — opt-in RAG
 


### PR DESCRIPTION
## Summary

`RAG_CORPORA` in `HostPage.tsx:104` listed 6 entries, but **only 2 correspond to real Qdrant collections**:

- `""` — No corpus (staff-only hints)
- `aegis_taiwan` — the Taiwan Wikipedia demo (seeded via `engine seed --corpus docs/rag/taiwan.md`)
- `demo-rag-general` — **never seeded**
- `demo-rag-engineering` — **never seeded**
- `demo-rag-sales` — **never seeded**
- `demo-rag-support` — **never seeded**

Selecting one of the four placeholders routed `CreateMeeting` with a `rag_id` that the engine's retriever couldn't resolve, firing `Retriever: no matches in '<missing>'` every flush window. Drop the placeholders so the dropdown shows only real options.

## Incidental polish

The `aegis_taiwan` option's label dropped internal jargon ("Slice 6 seeded") for user-meaningful framing ("zh-TW Wikipedia demo") — matches the corpus's actual provenance per `docs/rag/taiwan.md`'s attribution header.

The top comment block is refreshed to explain WHY the list is authored here (no `ListCorpora` RPC today) and WHY listing non-existent collections was the specific harm being backed out.

## Test plan

- [x] `./tools/scripts/frontend.sh typecheck` — clean.
- [x] `./tools/scripts/frontend.sh test` — 33/33 PASSED (no tests reference the removed labels).
- [x] Pre-commit hooks pass.
- [ ] CI green.
- [ ] User visual verification: dropdown shows exactly 2 entries.

## Follow-up (not in this PR)

Dynamic `ListCorpora` RPC so the dropdown reflects the actual Qdrant collection list instead of a TS const. Today Phase 3 ships one corpus, so the hardcoded approach is tolerable; a multi-corpus deployment would need gateway → Qdrant list-collections + gRPC proxy to frontend. Tracked conceptually in the refreshed code comment; no ticket yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)