### PR TITLE
feat(phase-4e-3): propagate Cognito tenant_id through gateway handlers

### DIFF
--- a/gateway_go/internal/grpc/BUILD.bazel
+++ b/gateway_go/internal/grpc/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         # Bazel-authoritative proto codegen per ADR-0013.
         "//proto/aegis/v1:aegis_go_proto",
+        "//gateway_go/internal/auth",
         "//gateway_go/internal/session",
         "//gateway_go/internal/token",
         "@org_golang_google_grpc//codes",
@@ -24,6 +25,7 @@ go_test(
     embed = [":grpc"],
     deps = [
         "//proto/aegis/v1:aegis_go_proto",
+        "//gateway_go/internal/auth",
         "//gateway_go/internal/session",
         "//gateway_go/internal/token",
         "@org_golang_google_grpc//:grpc",

--- a/gateway_go/internal/grpc/gateway_service.go
+++ b/gateway_go/internal/grpc/gateway_service.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	aegisv1 "github.com/BinHsu/aegis-core/gateway_go/gen/go/aegis/v1"
+	"github.com/BinHsu/aegis-core/gateway_go/internal/auth"
 	"github.com/BinHsu/aegis-core/gateway_go/internal/session"
 	"github.com/BinHsu/aegis-core/gateway_go/internal/token"
 )
@@ -206,7 +207,7 @@ func (s *GatewayService) CreateMeeting(
 	}
 
 	sess, err := s.registry.Create(session.Config{
-		TenantID:                "", // Local mode (ADR-0007 L7); A5 wires Cognito.
+		TenantID:                effectiveTenantID(ctx),
 		RAGID:                   req.GetRagId(),
 		Title:                   req.GetTitle(),
 		LanguageHints:           req.GetLanguageHints(),
@@ -557,16 +558,43 @@ func (s *GatewayService) SendOfficerHint(
 
 // Phase 3 demo tenant — the LAN deployment is single-tenant so the
 // gateway overrides whatever `tenant_id` the client sent with this
-// constant. Phase 4 replaces this with a JWT-derived tenant
-// (ADR-0022 §Decision).
+// constant. LOCAL mode stays on this for the LAN-demo convention
+// (collections are `aegis_demo_*`); CLOUD mode derives the tenant
+// from the JWT-issued Principal per ADR-0022 §Decision.
 const phase3DefaultTenant = "demo"
 
+// effectiveTenantID resolves the authenticated Principal on ctx to
+// the tenant_id used for engine-side filtering per ADR-0022 §"Schema
+// shape" + §"Query path". Never trusts client-sent tenant_id on the
+// wire — the gateway is the enforcement point.
+//
+// Rules:
+//   - LOCAL mode: returns "demo" (phase3DefaultTenant). LAN demo is
+//     single-tenant; all seeded collections are `aegis_demo_*`.
+//   - CLOUD mode: returns Principal.TenantID. OIDCProvider enforces
+//     non-empty `custom:tenant_id` upstream, so this is guaranteed
+//     populated by the time the handler runs.
+//   - No Principal on ctx: falls through to LOCAL (phase3DefaultTenant).
+//     The auth interceptor always runs in production so this path is
+//     a defensive fallback for test ergonomics and misconfigured
+//     bootstrap (better to serve the LAN-demo tenant than to 500).
+func effectiveTenantID(ctx context.Context) string {
+	p, ok := auth.FromContext(ctx)
+	if !ok {
+		return phase3DefaultTenant
+	}
+	if p.Mode == auth.ModeCloud && p.TenantID != "" {
+		return p.TenantID
+	}
+	return phase3DefaultTenant
+}
+
 // ListCorpora returns the RAG corpora the caller can bind to a new
-// meeting. The Host UI populates its dropdown from the response. The
-// gateway currently overrides the wire `tenant_id` with the hardcoded
-// Phase 3 value; when Phase 4 wires Cognito, this is where the JWT
-// claim substitution happens (same enforcement point — never trust
-// the client's `tenant_id`).
+// meeting. The Host UI populates its dropdown from the response.
+// Wire `tenant_id` on the request is IGNORED — the gateway always
+// substitutes the Principal's tenant (ADR-0022 §Decision
+// enforcement point). This keeps a malicious client from enumerating
+// other tenants' collections by sending their tenant_id on the wire.
 //
 // Error mapping:
 //   - UNIMPLEMENTED   — Gateway was constructed without an engine
@@ -576,11 +604,11 @@ func (s *GatewayService) ListCorpora(
 	ctx context.Context,
 	req *aegisv1.ListCorporaRequest,
 ) (*aegisv1.ListCorporaResponse, error) {
-	_ = req // Phase 3: wire tenant_id is ignored; see comment above.
+	_ = req // Wire tenant_id intentionally ignored — see doc above.
 	if s.listCorpora == nil {
 		return nil, status.Error(codes.Unimplemented, "ListCorpora not wired")
 	}
-	resp, err := s.listCorpora(ctx, phase3DefaultTenant)
+	resp, err := s.listCorpora(ctx, effectiveTenantID(ctx))
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "engine ListCorpora: %v", err)
 	}

--- a/gateway_go/internal/grpc/gateway_service_test.go
+++ b/gateway_go/internal/grpc/gateway_service_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	aegisv1 "github.com/BinHsu/aegis-core/gateway_go/gen/go/aegis/v1"
+	"github.com/BinHsu/aegis-core/gateway_go/internal/auth"
 	"github.com/BinHsu/aegis-core/gateway_go/internal/session"
 	"github.com/BinHsu/aegis-core/gateway_go/internal/token"
 )
@@ -855,9 +856,11 @@ func TestListCorporaUnimplementedWhenNotWired(t *testing.T) {
 }
 
 func TestListCorporaOverridesTenantIDToDemo(t *testing.T) {
-	// The gateway must substitute phase3DefaultTenant regardless of what
-	// the client sent — guards against client enumeration of other
-	// tenants' collection names (ADR-0022 enforcement point).
+	// The gateway must substitute the Principal's tenant regardless of
+	// what the client sent — guards against client enumeration of
+	// other tenants' collection names (ADR-0022 enforcement point).
+	// No Principal on ctx (bufconn client strips interceptors) falls
+	// back to phase3DefaultTenant = "demo" per effectiveTenantID().
 	var capturedTenant string
 	svc := newTestService(t, fakeEngineHealth(&aegisv1.HealthResponse{Ready: true}))
 	svc.listCorpora = func(ctx context.Context, tenantID string) (*aegisv1.ListCorporaResponse, error) {
@@ -887,6 +890,176 @@ func TestListCorporaOverridesTenantIDToDemo(t *testing.T) {
 	}
 	if got := resp.GetCorpora()[0].GetId(); got != "aegis_demo_taiwan" {
 		t.Fatalf("corpus id: got %q, want %q", got, "aegis_demo_taiwan")
+	}
+}
+
+// TestListCorporaSubstitutesCloudPrincipalTenant verifies that when a
+// Cloud-mode Principal is on ctx, ListCorpora forwards the Principal's
+// tenant (from the Cognito `custom:tenant_id` claim) to the engine,
+// and NOT whatever the wire request claimed. ADR-0022 §Decision hard
+// rule: gateway is the tenant-derivation authority; clients cannot
+// pivot via the wire field.
+func TestListCorporaSubstitutesCloudPrincipalTenant(t *testing.T) {
+	var capturedTenant string
+	svc := newTestService(t, fakeEngineHealth(&aegisv1.HealthResponse{Ready: true}))
+	svc.listCorpora = func(ctx context.Context, tenantID string) (*aegisv1.ListCorporaResponse, error) {
+		capturedTenant = tenantID
+		return &aegisv1.ListCorporaResponse{}, nil
+	}
+
+	// Call the handler directly with an injected Cloud Principal —
+	// the bufconn client path doesn't run the auth interceptor in
+	// these tests, so we skip the client hop for Principal-aware
+	// coverage.
+	ctx := auth.WithPrincipal(context.Background(), auth.Principal{
+		UserID: "cognito-user-abc", TenantID: "tenant-alpha", Mode: auth.ModeCloud,
+	})
+	_, err := svc.ListCorpora(ctx, &aegisv1.ListCorporaRequest{
+		TenantId: "attacker-tenant", // malicious: tries to enumerate another tenant
+	})
+	if err != nil {
+		t.Fatalf("ListCorpora: %v", err)
+	}
+	if capturedTenant != "tenant-alpha" {
+		t.Fatalf("gateway did not forward Principal tenant: got %q, want %q",
+			capturedTenant, "tenant-alpha")
+	}
+}
+
+// TestListCorporaLocalPrincipalResolvesToDemo confirms LOCAL mode
+// falls through to "demo" even when an explicit Principal is on ctx
+// (ModeLocal, empty TenantID is the canonical shape per auth.go).
+// This keeps LAN-demo behavior stable under the new wiring.
+func TestListCorporaLocalPrincipalResolvesToDemo(t *testing.T) {
+	var capturedTenant string
+	svc := newTestService(t, fakeEngineHealth(&aegisv1.HealthResponse{Ready: true}))
+	svc.listCorpora = func(ctx context.Context, tenantID string) (*aegisv1.ListCorporaResponse, error) {
+		capturedTenant = tenantID
+		return &aegisv1.ListCorporaResponse{}, nil
+	}
+
+	ctx := auth.WithPrincipal(context.Background(), auth.Principal{
+		UserID: "local", TenantID: "", Mode: auth.ModeLocal,
+	})
+	_, err := svc.ListCorpora(ctx, &aegisv1.ListCorporaRequest{
+		TenantId: "anything", // wire field should still be ignored
+	})
+	if err != nil {
+		t.Fatalf("ListCorpora: %v", err)
+	}
+	if capturedTenant != "demo" {
+		t.Fatalf("Local mode tenant resolution: got %q, want %q",
+			capturedTenant, "demo")
+	}
+}
+
+// TestCreateMeetingPopulatesSessionTenantFromCloudPrincipal —
+// ADR-0022 end-to-end on the gateway side: a Cloud-mode Principal's
+// tenant flows into session.Config.TenantID, and from there into the
+// SessionStart proto the pipeline sends to the engine, where the
+// engine's Qdrant filter (ADR-0022 §Query path) picks it up.
+func TestCreateMeetingPopulatesSessionTenantFromCloudPrincipal(t *testing.T) {
+	svc := newTestService(t, fakeEngineHealth(&aegisv1.HealthResponse{Ready: true}))
+
+	ctx := auth.WithPrincipal(context.Background(), auth.Principal{
+		UserID: "cognito-user-abc", TenantID: "tenant-alpha", Mode: auth.ModeCloud,
+	})
+	resp, err := svc.CreateMeeting(ctx, &aegisv1.CreateMeetingRequest{
+		RagId: "some-corpus",
+		Title: "Phase 4e-3 isolation check",
+	})
+	if err != nil {
+		t.Fatalf("CreateMeeting: %v", err)
+	}
+
+	sess, err := svc.registry.Get(resp.GetSessionId())
+	if err != nil {
+		t.Fatalf("registry.Get: %v", err)
+	}
+	if sess.TenantID != "tenant-alpha" {
+		t.Fatalf("session.TenantID: got %q, want %q",
+			sess.TenantID, "tenant-alpha")
+	}
+}
+
+// TestCreateMeetingLocalPrincipalPopulatesDemo — the LAN-demo
+// convention: LOCAL principal's empty TenantID resolves to "demo" in
+// the created session, so the engine queries the `aegis_demo_*`
+// collections the LAN seed script populates.
+func TestCreateMeetingLocalPrincipalPopulatesDemo(t *testing.T) {
+	svc := newTestService(t, fakeEngineHealth(&aegisv1.HealthResponse{Ready: true}))
+
+	ctx := auth.WithPrincipal(context.Background(), auth.Principal{
+		UserID: "local", TenantID: "", Mode: auth.ModeLocal,
+	})
+	resp, err := svc.CreateMeeting(ctx, &aegisv1.CreateMeetingRequest{
+		RagId: "",
+		Title: "LAN smoke",
+	})
+	if err != nil {
+		t.Fatalf("CreateMeeting: %v", err)
+	}
+
+	sess, err := svc.registry.Get(resp.GetSessionId())
+	if err != nil {
+		t.Fatalf("registry.Get: %v", err)
+	}
+	if sess.TenantID != "demo" {
+		t.Fatalf("Local-mode session.TenantID: got %q, want %q",
+			sess.TenantID, "demo")
+	}
+}
+
+// TestCreateMeetingCrossTenantIsolationStructural — ADR-0022 hard
+// boundary: two back-to-back CreateMeeting calls with different
+// Cloud Principals produce sessions with disjoint TenantIDs, which
+// propagate into the engine's collection namespace
+// `aegis_<tenant_id>_<corpus>`. A retrieval from tenant-alpha
+// cannot accidentally reach tenant-beta's collection because they
+// literally don't share a collection name. This is the STRUCTURAL
+// part of §Query path (the filter-level per-user isolation is 4e-4
+// integration coverage).
+func TestCreateMeetingCrossTenantIsolationStructural(t *testing.T) {
+	svc := newTestService(t, fakeEngineHealth(&aegisv1.HealthResponse{Ready: true}))
+
+	alphaCtx := auth.WithPrincipal(context.Background(), auth.Principal{
+		UserID: "user-1", TenantID: "tenant-alpha", Mode: auth.ModeCloud,
+	})
+	betaCtx := auth.WithPrincipal(context.Background(), auth.Principal{
+		UserID: "user-2", TenantID: "tenant-beta", Mode: auth.ModeCloud,
+	})
+
+	alphaResp, err := svc.CreateMeeting(alphaCtx, &aegisv1.CreateMeetingRequest{
+		RagId: "corpus-x",
+	})
+	if err != nil {
+		t.Fatalf("alpha CreateMeeting: %v", err)
+	}
+	betaResp, err := svc.CreateMeeting(betaCtx, &aegisv1.CreateMeetingRequest{
+		RagId: "corpus-x", // same corpus name — tenant-prefixed separately on engine side
+	})
+	if err != nil {
+		t.Fatalf("beta CreateMeeting: %v", err)
+	}
+
+	alphaSess, err := svc.registry.Get(alphaResp.GetSessionId())
+	if err != nil {
+		t.Fatalf("alpha registry.Get: %v", err)
+	}
+	betaSess, err := svc.registry.Get(betaResp.GetSessionId())
+	if err != nil {
+		t.Fatalf("beta registry.Get: %v", err)
+	}
+
+	if alphaSess.TenantID == betaSess.TenantID {
+		t.Fatalf("cross-tenant leak: alpha and beta share TenantID %q",
+			alphaSess.TenantID)
+	}
+	if alphaSess.TenantID != "tenant-alpha" {
+		t.Errorf("alpha tenant: got %q, want tenant-alpha", alphaSess.TenantID)
+	}
+	if betaSess.TenantID != "tenant-beta" {
+		t.Errorf("beta tenant: got %q, want tenant-beta", betaSess.TenantID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Third slice of Phase 4e — wires the authenticated Principal's tenant_id from the gateway auth interceptor through \`CreateMeeting\` and \`ListCorpora\`, completing the gateway-side enforcement point for ADR-0022 multi-tenancy isolation.

**Closes ADR-0034 Open Question 2** (gateway pipeline tenant_id forwarding verification).

## Key finding during recon

The propagation wiring was **almost entirely already there**:
- \`gateway_go/internal/pipeline/pipeline.go:147\` — forwards \`sess.TenantID\` into engine's \`SessionStart\` proto message ✓
- \`engine_cpp/src/grpc/aegis_engine_service.cc:113-148\` — reads \`tenant_id\` for \`ListCorpora\` prefix filter \`aegis_<tenant_id>_*\` ✓
- \`engine_cpp/src/rag/retriever.h:72\` — comments that collection name follows \`aegis_<tenant>_<corpus_stem>\` per ADR-0022 ✓

**The gap was only on the gateway side** — two handlers were hardcoding the tenant value instead of deriving it from the authenticated Principal:
- \`gateway_service.go:209\`: \`TenantID: "", // Local mode (ADR-0007 L7); A5 wires Cognito.\`
- \`gateway_service.go:583\`: \`resp, err := s.listCorpora(ctx, phase3DefaultTenant)\`

## Change

New helper \`effectiveTenantID(ctx)\` resolves the Principal on ctx to the engine-side tenant_id:

| Principal on ctx | tenant_id used |
|---|---|
| CLOUD mode (TenantID set) | \`Principal.TenantID\` — flows from Cognito \`custom:tenant_id\` claim |
| LOCAL mode (ModeLocal, empty TenantID) | \`"demo"\` (phase3DefaultTenant, LAN convention) |
| No Principal (unit test, misconfigured) | \`"demo"\` defensive fallback |

Applied in two places:
- \`CreateMeeting\`: populates \`session.Config.TenantID\` → pipeline forwards to engine via \`SessionStart\` → engine uses for Qdrant collection namespace per ADR-0022 §Schema shape
- \`ListCorpora\`: passes to engine. **Wire \`TenantId\` field remains IGNORED** — gateway is the sole derivation authority per ADR-0022 §Decision. Doc comment rewritten to explicitly call out "never trust client tenant_id".

## Test plan

6 test cases covering all branches of \`effectiveTenantID\`:

- [x] \`TestListCorporaOverridesTenantIDToDemo\` (updated) — no Principal → \`"demo"\` fallback
- [x] \`TestListCorporaSubstitutesCloudPrincipalTenant\` (new) — Cloud Principal + malicious wire tenant_id → Principal's tenant flows through, wire value ignored
- [x] \`TestListCorporaLocalPrincipalResolvesToDemo\` (new) — explicit Local Principal → \`"demo"\`
- [x] \`TestCreateMeetingPopulatesSessionTenantFromCloudPrincipal\` (new) — Cloud Principal → \`session.TenantID\` populated
- [x] \`TestCreateMeetingLocalPrincipalPopulatesDemo\` (new) — Local Principal → \`session.TenantID = "demo"\`
- [x] \`TestCreateMeetingCrossTenantIsolationStructural\` (new) — two Cloud Principals with disjoint tenants → sessions have disjoint TenantIDs (ADR-0022 STRUCTURAL boundary test)

\`\`\`
./tools/bazelisk/bazelisk test //gateway_go/internal/grpc:grpc_test  → PASSED
./tools/bazelisk/bazelisk test //gateway_go/internal/auth:auth_test  → PASSED (cached)
./tools/bazelisk/bazelisk build //gateway_go/cmd/gateway:gateway     → build clean
\`\`\`

## Deliberately NOT in scope

- **Engine-side AuthContext interceptor** — not needed. The engine already reads \`tenant_id\` from the \`SessionStart\` proto (populated by pipeline from \`session.TenantID\`) and from \`ListCorporaRequest.tenant_id\` (populated by gateway's \`listCorpora\` closure). No additional metadata plumbing required on the engine side.

- **4e-4 Qdrant filter-level per-user isolation test** — blocked on LDZ cold-start + Cognito Dev User Pool. This PR covers the STRUCTURAL boundary (disjoint collection namespaces per tenant); the FILTER-level within-tenant user isolation (same tenant, different users → Qdrant \`user_id\` payload filter) comes with real Qdrant + multi-user seed in 4e-4.

## LOCAL mode

Preserved unchanged. \`VITE_AEGIS_DEPLOY_MODE=local\` (SPA) + \`DEPLOY_MODE=local\` (gateway) still produce synthetic \`"local"\` Principal → \`effectiveTenantID\` resolves to \`"demo"\` → LAN seed collections \`aegis_demo_*\` work as before. Zero regression expected for the Phase 3 LAN demo.

Refs: ADR-0034 §D3 + OQ-2, ADR-0022 §Schema shape + §Query path, aegis-core#76

🤖 Generated with [Claude Code](https://claude.com/claude-code)