### PR TITLE
feat(phase-4c-5a): convert Deployment to Argo Rollouts CRD (gateway + engine)

### DIFF
--- a/apps/staging/aegis-engine/rollout.yaml
+++ b/apps/staging/aegis-engine/rollout.yaml
@@ -1,5 +1,5 @@
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
 metadata:
   name: aegis-engine
   namespace: aegis
@@ -7,6 +7,20 @@ metadata:
     app.kubernetes.io/name: aegis-engine
     app.kubernetes.io/part-of: aegis-core
     app.kubernetes.io/component: inference-engine
+# Phase 4c-5a: ADR-0030 Progressive Delivery Controller — engine
+# half. Deployment → Rollout conversion matches the gateway; engine
+# uses a longer soak (5m vs 2m) because model load at startup takes
+# ~30 seconds and a new canary pod needs enough warm-up time for
+# health-check stability before the operator commits to promote.
+#
+# Engine is cluster-internal (no Ingress / ALB), so the ALB
+# trafficRouting discussion on the gateway side doesn't apply here —
+# canary weight maps cleanly to ReplicaSet replica counts and the
+# Service (headless, ADR-0017) round-robins across both ReplicaSets
+# naturally. ALB plugin is gateway-only.
+#
+# AnalysisTemplate SLO gates deferred per ADR-0030 §"Honest phasing"
+# — lands alongside Phase 4d metric pipeline (C-5b).
 spec:
   # N replicas per ADR-0017 N:N-ready topology. Starting at 2 in
   # staging to exercise the round-robin path end-to-end.
@@ -16,10 +30,15 @@ spec:
     matchLabels:
       app.kubernetes.io/name: aegis-engine
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+    canary:
+      # 50/50 for 5 minutes — longer than gateway's 2m because engine
+      # boot cost includes manifest CAS walk + whisper model mmap
+      # + optional bge-m3 load. The pause lets operators confirm the
+      # canary ReplicaSet settled into Ready state before promoting.
+      steps:
+        - setWeight: 50
+        - pause:
+            duration: 5m
   template:
     metadata:
       labels:

--- a/apps/staging/aegis-gateway/rollout.yaml
+++ b/apps/staging/aegis-gateway/rollout.yaml
@@ -1,5 +1,5 @@
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
 metadata:
   name: aegis-gateway
   namespace: aegis
@@ -7,6 +7,22 @@ metadata:
     app.kubernetes.io/name: aegis-gateway
     app.kubernetes.io/part-of: aegis-core
     app.kubernetes.io/component: api-gateway
+# Phase 4c-5a initial slice of ADR-0030 Progressive Delivery Controller:
+# Deployment → Rollout CRD conversion. The controller + ALB traffic-
+# router plugin are installed cluster-side (ldz #103 closed 2026-04-23).
+#
+# Scope reduction — these ADR-0030 items are deferred to follow-up
+# slices rather than bundled here:
+#
+#   - ALB trafficRouting (canaryService + stableService + TargetGroup
+#     weight shifts) — C-5a follow-up. Without it, `setWeight` at this
+#     layer means "split ReplicaSet replica counts"; traffic still
+#     follows the Service load-balance across all matching pods, which
+#     at 2 replicas gives a usable 50/50 canary without the
+#     TargetGroupBinding wiring.
+#   - AnalysisTemplate SLO gates — C-5b, explicitly deferred per
+#     ADR-0030 §"Honest phasing" until Phase 4d emits the burn-rate
+#     metrics that drive automatic rollback.
 spec:
   # Two replicas to exercise ADR-0017's N:N assumption in staging.
   # Scaling policy (HPA) deferred until Phase 4d emits metrics.
@@ -16,10 +32,16 @@ spec:
     matchLabels:
       app.kubernetes.io/name: aegis-gateway
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+    canary:
+      # 50/50 soak for 2 minutes before the Rollout promotes the canary
+      # ReplicaSet to stable. Deliberately minimal pending the Phase 4d
+      # SLO-gated AnalysisTemplate (C-5b). Time-based pause gives
+      # operators a window to eyeball logs / dashboards before full
+      # promote; auto-rollback lands with the metric pipeline.
+      steps:
+        - setWeight: 50
+        - pause:
+            duration: 2m
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Summary

First slice of Phase 4c-5a per [ADR-0030](docs/adr/0030-progressive-delivery-controller.md). Both \`aegis-gateway\` and \`aegis-engine\` convert \`apps/v1.Deployment\` → \`argoproj.io/v1alpha1.Rollout\`; step-based canary replaces the vanilla RollingUpdate. Landing against a live ecosystem — [ldz #103](https://github.com/BinHsu/aegis-aws-landing-zone/issues/103) (Argo Rollouts controller + ALB traffic-router plugin) closed 2026-04-23.

## Canary steps

| Workload | \`setWeight\` | \`pause\` | Rationale |
|---|---|---|---|
| gateway | 50 | 2m | Matches 30s drain + operator log-eyeball window |
| engine  | 50 | 5m | Longer soak — engine boot = manifest CAS walk + whisper mmap + optional bge-m3 load |

## Scope reduction (deliberately separate slices)

- **ALB trafficRouting** (canaryService + stableService + TargetGroupBinding) — C-5a follow-up PR. Without it, \`setWeight\` maps to ReplicaSet replica counts; at 2 replicas that gives a usable 50/50 canary (Service load-balance across both ReplicaSets), just without the precise ALB weight control.
- **AnalysisTemplate SLO gates + automatic rollback** — C-5b, explicitly deferred per ADR-0030 §"Honest phasing" until Phase 4d metric pipeline emits the burn-rate signals. Time-based pause stands in for now.

## File changes

| Before | After | Why |
|---|---|---|
| \`apps/staging/aegis-gateway/deployment.yaml\` | \`apps/staging/aegis-gateway/rollout.yaml\` | \`kind: Rollout\` should not live in a file named \`deployment.yaml\` |
| \`apps/staging/aegis-engine/deployment.yaml\` | \`apps/staging/aegis-engine/rollout.yaml\` | ditto |

service.yaml / ingress.yaml / networkpolicy.yaml / serviceaccount.yaml / servicemonitor.yaml — **unchanged**. Rollout's pod template preserves \`app.kubernetes.io/name\` labels, so Service selectors keep matching without a selector change.

## Test plan

- [x] YAML parses (no lint errors in the new \`apiVersion\`/\`kind\`/\`strategy.canary\` sections)
- [x] File rename shows as rename in git diff (not full-delete + full-add)
- [ ] Cold-apply smoke on LDZ — blocked on LDZ cold-start (memory notes cluster torn down 2026-04-22)

Refs: ADR-0030, ADR-0017, ADR-0006, ldz #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)