### PR TITLE
feat(phase-4c): post-deploy E2E Playwright spec + nightly workflow

### DIFF
--- a/.github/workflows/postdeploy-e2e.yml
+++ b/.github/workflows/postdeploy-e2e.yml
@@ -1,0 +1,103 @@
+name: Post-deploy E2E smoke
+
+# Phase 4c post-deploy E2E workflow per ROADMAP. Runs the Playwright
+# spec at `frontend_web/e2e/postdeploy-happy-path.spec.ts` against
+# the deployed staging URL.
+#
+# Trigger model:
+#
+#   - Nightly cron (03:00 UTC) so regressions land in the oncall
+#     window of the next operator review, not in the middle of a
+#     live meeting.
+#   - Manual `workflow_dispatch` for targeted runs after a cold-apply
+#     or a deliberate staging change.
+#
+# Gating:
+#
+# The workflow is committed now (Phase 4c slice) but runs as a no-op
+# when the `AEGIS_POSTDEPLOY_URL` repository secret is unset — that
+# matches the present state where ldz's staging cluster is torn down
+# (see `project_ldz_teardown_state.md` in the operator's notes).
+# When ldz cold-starts and `aegis-app.staging.binhsu.org` comes back
+# online, an operator sets the secret and the cron flips from "skip"
+# to "run" automatically.
+#
+# Why nightly (not per-commit): post-deploy E2E tests the *deployed*
+# surface, not the pre-merge code. Running it per-commit would test
+# the current main against whatever previous version happens to be
+# deployed — not useful. The right cadence is "after every ArgoCD
+# sync, plus a nightly safety net"; the ArgoCD-sync hook is a
+# future slice (needs webhook plumbing on the cluster side).
+#
+# Refs: ROADMAP.md Phase 4c "Post-deploy E2E suite against staging";
+# ADR-0002 Constraint 4 (webkit parity); Incident 09 rationale for
+# live-browser harnesses.
+
+on:
+  schedule:
+    # 03:00 UTC = 11:00 Taipei daylight, 10:00 Taipei standard.
+    # Lands before the typical morning operator review.
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: postdeploy-e2e
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  playwright:
+    name: Playwright against staging
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Short-circuit if AEGIS_POSTDEPLOY_URL unset
+        id: gate
+        env:
+          POSTDEPLOY_URL: ${{ secrets.AEGIS_POSTDEPLOY_URL }}
+        run: |
+          if [ -z "${POSTDEPLOY_URL:-}" ]; then
+            echo "AEGIS_POSTDEPLOY_URL secret is unset — skipping."
+            echo "Set it to the staging URL (e.g. https://aegis-app.staging.binhsu.org)"
+            echo "on the repository's Secrets page to enable the real run."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install frontend deps
+        if: steps.gate.outputs.should_run == 'true'
+        run: ./tools/scripts/frontend.sh install
+
+      - name: Install Playwright browsers
+        if: steps.gate.outputs.should_run == 'true'
+        run: ./tools/scripts/frontend.sh e2e:install
+
+      - name: Run post-deploy spec
+        if: steps.gate.outputs.should_run == 'true'
+        env:
+          AEGIS_POSTDEPLOY_URL: ${{ secrets.AEGIS_POSTDEPLOY_URL }}
+          # Forward CI=true so the Playwright config applies its
+          # retry=1 + github-reporter posture.
+          CI: "true"
+        run: |
+          cd frontend_web
+          # -g runs only the `postdeploy-happy-path` spec; the
+          # existing `consent-smoke` spec stays scoped to pre-merge CI
+          # (ci-baseline.yml) because it needs the local Vite server.
+          node node_modules/@playwright/test/cli.js test \
+            --reporter=github \
+            -g "post-deploy happy-path smoke"
+
+      - name: Upload Playwright report on failure
+        if: failure() && steps.gate.outputs.should_run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-postdeploy
+          path: frontend_web/playwright-report/
+          retention-days: 7

--- a/frontend_web/e2e/postdeploy-happy-path.spec.ts
+++ b/frontend_web/e2e/postdeploy-happy-path.spec.ts
@@ -1,0 +1,105 @@
+// frontend_web/e2e/postdeploy-happy-path.spec.ts
+//
+// Phase 4c post-deploy E2E skeleton per ROADMAP: runs against the
+// deployed staging URL after every ArgoCD sync (or on a nightly
+// schedule) and fails loudly when the live site regresses the
+// chief-of-staff user journey.
+//
+// Scope today (initial slice):
+//
+//   - Landing page loads, header renders
+//   - /host route is reachable and shows the pre-sign-in call-to-action
+//     (Local mode: "Sign in (local)"; Cloud mode: "Sign in with Cognito")
+//   - /view/<sessionId>?token=<garbage> route renders an error-state
+//     rather than a blank screen (catches SPA routing regressions
+//     where 404s or empty bundles silently ship)
+//
+// Out of scope today (tracked for follow-up extension when the live
+// loop is ready to drive):
+//
+//   - Full CreateMeeting → audio → transcript → JoinAsViewer →
+//     EndMeeting flow per ROADMAP "post-deploy E2E suite against
+//     staging". Blocked on two things:
+//       * Real audio in a headless browser — Playwright supports
+//         `--use-fake-device-for-media-stream` for chromium but
+//         webkit is thinner; we'd need a dedicated audio fixture
+//         (.wav) served into getUserMedia to stand in for a mic.
+//       * Real Cognito login — waits on ldz staging/auth/ Terraform
+//         apply (ADR-0026 Partially Accepted, aegis-core#76). When
+//         the Dev User Pool is live, we'll drive `AdminInitiateAuth`
+//         programmatically and inject the ID token rather than
+//         driving the Hosted UI.
+//   - WebRTC handshake verification (needs real STUN / TURN reach-
+//     ability on the Playwright runner).
+//
+// The spec skips in CI unless `AEGIS_POSTDEPLOY_URL` is set — local
+// dev can run against the Vite dev server by exporting the env var
+// to `http://127.0.0.1:5173`. That lets the spec be authored + kept
+// green on laptop while the nightly CI workflow sits gated on the
+// real staging URL surfacing in GH Secrets.
+
+import { test, expect } from "@playwright/test";
+
+const BASE_URL = process.env["AEGIS_POSTDEPLOY_URL"];
+
+test.describe("post-deploy happy-path smoke", () => {
+  test.beforeAll(() => {
+    if (!BASE_URL) {
+      test.skip(
+        true,
+        "AEGIS_POSTDEPLOY_URL not set — running in gating mode. " +
+          "Export it to a staging or dev URL to exercise the spec.",
+      );
+    }
+  });
+
+  test("landing page renders", async ({ page }) => {
+    // BASE_URL is non-null here by virtue of the beforeAll skip, but
+    // TypeScript doesn't track that — guard for its benefit.
+    if (!BASE_URL) return;
+    await page.goto(BASE_URL);
+    // The App shell renders the product name in the header; if the
+    // bundle failed to load or a client-side error blanked the tree,
+    // the heading is absent and this fails with a useful locator
+    // snapshot rather than "page is blank".
+    await expect(page.locator("h1, h2").first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("/host shows the sign-in call-to-action", async ({ page }) => {
+    if (!BASE_URL) return;
+    await page.goto(`${BASE_URL}/host`);
+    // The pre-signed-in HostPage has a single primary CTA button;
+    // text is one of:
+    //   - "Sign in with Cognito"   (Cloud build)
+    //   - "Sign in (local)"        (Local build)
+    // Match either so this spec works against both deploy flavors.
+    const cta = page.getByRole("button", {
+      name: /Sign in (with Cognito|\(local\))/,
+    });
+    await expect(cta).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("/view/<id>?token=<garbage> renders an error rather than blanking", async ({
+    page,
+  }) => {
+    if (!BASE_URL) return;
+    // A bad token on the viewer path should surface a visible error
+    // panel, not a blank React tree. Catches SPA routing regressions
+    // where a 404 or a runtime-unhandled rejection blanks the screen.
+    await page.goto(
+      `${BASE_URL}/view/nonexistent-session?token=definitely-not-a-valid-jwt`,
+    );
+    // The ViewerPage emits a distinctive error region when the
+    // session fails to resolve; assert any user-visible text in the
+    // error treatment surfaces.
+    await expect(page.locator("main").first()).toBeVisible({
+      timeout: 10_000,
+    });
+    // Don't assert a specific error message — the copy may evolve;
+    // asserting "the page rendered something" is the load-bearing
+    // claim ("not blank"), and copy-level assertions would produce
+    // flaky noise.
+  });
+});


### PR DESCRIPTION
Phase 4c post-deploy E2E skeleton per ROADMAP. Adds a Playwright spec that runs against the deployed staging URL + a nightly workflow gated on `AEGIS_POSTDEPLOY_URL` secret. Current spec coverage is framework-level (landing renders, /host CTA visible, /view error state non-blank); full CreateMeeting → audio → transcript → JoinAsViewer loop deferred pending (a) real-audio fixture into headless getUserMedia + (b) Cognito Dev User Pool from ldz. Workflow no-ops today because the staging cluster is torn down; flips to run automatically once an operator sets the secret post-cold-start.