### PR TITLE
feat(phase-4d): domain metrics — hints_emitted_total + host_transient_loss_total

### DIFF
--- a/gateway_go/cmd/gateway/main.go
+++ b/gateway_go/cmd/gateway/main.go
@@ -237,6 +237,7 @@ func main() {
 					switch state {
 					case aegiswebrtc.ICEStateDisconnected:
 						_ = p.SendControl(aegisv1.ControlKind_CONTROL_KIND_PAUSE)
+						metrics.HostTransientLossTotal.Inc()
 					case aegiswebrtc.ICEStateConnected:
 						_ = p.SendControl(aegisv1.ControlKind_CONTROL_KIND_RESUME)
 					case aegiswebrtc.ICEStateFailed:

--- a/gateway_go/internal/grpc/BUILD.bazel
+++ b/gateway_go/internal/grpc/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         # Bazel-authoritative proto codegen per ADR-0013.
         "//proto/aegis/v1:aegis_go_proto",
         "//gateway_go/internal/auth",
+        "//gateway_go/internal/metrics",
         "//gateway_go/internal/session",
         "//gateway_go/internal/token",
         "@org_golang_google_grpc//codes",
@@ -26,6 +27,7 @@ go_test(
     deps = [
         "//proto/aegis/v1:aegis_go_proto",
         "//gateway_go/internal/auth",
+        "//gateway_go/internal/metrics",
         "//gateway_go/internal/session",
         "//gateway_go/internal/token",
         "@org_golang_google_grpc//:grpc",

--- a/gateway_go/internal/grpc/gateway_service.go
+++ b/gateway_go/internal/grpc/gateway_service.go
@@ -32,6 +32,7 @@ import (
 
 	aegisv1 "github.com/BinHsu/aegis-core/gateway_go/gen/go/aegis/v1"
 	"github.com/BinHsu/aegis-core/gateway_go/internal/auth"
+	"github.com/BinHsu/aegis-core/gateway_go/internal/metrics"
 	"github.com/BinHsu/aegis-core/gateway_go/internal/session"
 	"github.com/BinHsu/aegis-core/gateway_go/internal/token"
 )
@@ -551,6 +552,7 @@ func (s *GatewayService) SendOfficerHint(
 	// subscribers are visible via sequence gaps on the viewer side
 	// (same posture as transcript broadcast).
 	sess.Broadcast(ev)
+	metrics.HintsEmittedTotal.WithLabelValues("officer").Inc()
 
 	return &aegisv1.SendOfficerHintResponse{HintId: hintID}, nil
 }

--- a/gateway_go/internal/metrics/metrics.go
+++ b/gateway_go/internal/metrics/metrics.go
@@ -74,8 +74,76 @@ var RpcDurationSeconds = prometheus.NewHistogramVec(
 	[]string{"method"},
 )
 
+// -----------------------------------------------------------------------------
+// Domain metrics (Phase 4d / ROADMAP).
+//
+// Infrastructure metrics above answer "is the gateway healthy"; these
+// answer "is the product doing the work it's supposed to do". Both
+// feed the same Prometheus scrape, but the domain metrics are what
+// SLOs are defined against (ARCH §10.4) — the burn-rate denominator
+// for the Phase 4c-5b AnalysisTemplate lives here.
+// -----------------------------------------------------------------------------
+
+// HintsEmittedTotal — count of PrompterHint events the gateway has
+// broadcast to viewers, labelled by origin.
+//
+//   source="retriever"  — engine-origin RAG hits flowing from
+//                         `Pipeline.runEgress` on the `EgressMessage_Hint`
+//                         variant (ADR-0019 retriever path)
+//   source="officer"    — staff-authored hints via the
+//                         SendOfficerHint RPC handler (Phase 3c Slice 7)
+//
+// Useful for:
+//   - "is the retriever actually firing?" — alert on the ratio
+//     dropping to zero mid-meeting
+//   - "what fraction of hints are staff overrides?" — signals whether
+//     the retriever is under-performing vs the chief-of-staff's
+//     manual interventions
+var HintsEmittedTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "aegis_gateway_hints_emitted_total",
+		Help: "PrompterHint events broadcast to viewers, labelled by " +
+			"origin (retriever = engine RAG hit, officer = staff-authored).",
+	},
+	[]string{"source"},
+)
+
+// HostTransientLossTotal — count of host-side transient connection
+// losses (ICE Disconnected transitions, which PAUSE the engine
+// stream but keep the session alive for reconnect per ADR-0006).
+//
+// ICE Failed transitions are NOT counted here — those terminate
+// the session (END_STREAM) and are covered by the session-ended
+// telemetry. This counter captures the "laptop lid closed briefly"
+// / "WiFi blip" / "moved between APs" class of events where the
+// session is recoverable.
+//
+// Useful for:
+//   - environment-quality signal: a meeting with high transient-loss
+//     count likely has a flaky network and the transcript / RAG
+//     confidence interpretation should weight that
+//   - diagnostic pattern: sudden spike in transient_loss across all
+//     active sessions points at gateway-side ICE stack regression,
+//     not per-session network conditions
+var HostTransientLossTotal = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Name: "aegis_gateway_host_transient_loss_total",
+		Help: "Host-side ICE Disconnected transitions that PAUSE the " +
+			"engine stream but keep the session alive (transient loss " +
+			"per ADR-0006). Terminal ICE Failed transitions are NOT " +
+			"counted here.",
+	},
+)
+
 func init() {
-	registry.MustRegister(Up, ActiveSessions, RpcTotal, RpcDurationSeconds)
+	registry.MustRegister(
+		Up,
+		ActiveSessions,
+		RpcTotal,
+		RpcDurationSeconds,
+		HintsEmittedTotal,
+		HostTransientLossTotal,
+	)
 }
 
 // Handler returns the HTTP handler that serves /metrics. cmd/gateway

--- a/gateway_go/internal/pipeline/BUILD.bazel
+++ b/gateway_go/internal/pipeline/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/BinHsu/aegis-core/gateway_go/internal/pipeline",
     visibility = ["//gateway_go:__subpackages__"],
     deps = [
+        "//gateway_go/internal/metrics",
         "//gateway_go/internal/sensitive",
         "//gateway_go/internal/session",
         # Proto Go bindings — per ADR-0013, Bazel is authoritative for

--- a/gateway_go/internal/pipeline/pipeline.go
+++ b/gateway_go/internal/pipeline/pipeline.go
@@ -54,6 +54,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	aegisv1 "github.com/BinHsu/aegis-core/gateway_go/gen/go/aegis/v1"
+	"github.com/BinHsu/aegis-core/gateway_go/internal/metrics"
 	"github.com/BinHsu/aegis-core/gateway_go/internal/sensitive"
 	"github.com/BinHsu/aegis-core/gateway_go/internal/session"
 )
@@ -393,6 +394,7 @@ func (p *Pipeline) runEgress() {
 					Hint: payload.Hint,
 				},
 			})
+			metrics.HintsEmittedTotal.WithLabelValues("retriever").Inc()
 			if delivered == 0 {
 				slog.Warn("pipeline.broadcast.hint_no_subscribers",
 					"session_id", p.sessionID,


### PR DESCRIPTION
Phase 4d domain metrics per ROADMAP line 351. Adds two product-level signals distinct from C-Obs-1 infrastructure metrics: `aegis_gateway_hints_emitted_total{source}` covering both retriever + officer hint sources, and `aegis_gateway_host_transient_loss_total` for ICE Disconnected transitions per ADR-0006. `aegis_questions_detected_total` deliberately deferred — no detection code today, a zero-valued metric is worse than absent for alerting. Wiring at SendOfficerHint broadcast + Pipeline.runEgress hint branch + main.go ICE state switch. Tests green: grpc_test + pipeline_test both PASSED.