### PR TITLE
feat(phase-4c/4e): wire live ldz staging values — ACM ARN + Cognito env

### DIFF
--- a/.github/workflows/release-staging-frontend.yml
+++ b/.github/workflows/release-staging-frontend.yml
@@ -69,6 +69,34 @@ env:
   VITE_AEGIS_GATEWAY_ENDPOINT: https://${{ vars.GATEWAY_DOMAIN }}
   VITE_AEGIS_DEPLOY_MODE: cloud
 
+  # Cognito User Pool — provisioned in ldz `staging/auth/` per
+  # ldz ADR-026 + aegis-core #76 (resolved 2026-04-24 with PR ldz#140).
+  # Hard-coded rather than `vars.*` because:
+  #
+  #   1. All four values carry `lifecycle.prevent_destroy = true` on
+  #      the ldz side — they outlive workload teardowns. Stable IDs.
+  #   2. None are secrets — Pool ID, Client ID, hostnames are all
+  #      public surface in any browser network panel. SSM PS holds
+  #      the same values for non-secret programmatic read.
+  #   3. Adding 4 GH Variables for stable values would force every
+  #      fork operator into a UI dance for no payoff.
+  #
+  # If we ever pivot the staging User Pool ID (Runbook 008 §
+  # Permanent teardown), the swap is in this file + a re-deploy.
+  # Cross-reference: the same constants live in SSM PS at
+  # `/aegis/staging/cognito/{user-pool-id,app-client-id,issuer-url,
+  # hosted-ui-domain}` for any code path that prefers programmatic
+  # read over baked-in literals.
+  VITE_AEGIS_COGNITO_AUTHORITY: https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_0gdyxKxOB
+  # gitleaks heuristically flags the Client ID's entropy as an
+  # api-key. It isn't — Cognito app client IDs are PUBLIC by design
+  # (the SPA bundle ships them in plain JS, every browser network
+  # panel sees them). Inline allowlist is the right scope; adding a
+  # repo-wide rule would be over-broad.
+  VITE_AEGIS_COGNITO_CLIENT_ID: 1e7i376p7bitfup27gsqklg2hu # gitleaks:allow
+  VITE_AEGIS_COGNITO_REDIRECT_URI: https://aegis-app.staging.binhsu.org/auth/callback
+  VITE_AEGIS_COGNITO_LOGOUT_URI: https://aegis-app.staging.binhsu.org/
+
 jobs:
   release-staging-frontend:
     name: Build + sync staging frontend bundle

--- a/apps/staging/aegis-gateway/ingress.yaml
+++ b/apps/staging/aegis-gateway/ingress.yaml
@@ -16,11 +16,13 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/backend-protocol: HTTP
-    # Cross-repo dependency — ACM certificate for the hostname
-    # below is provisioned by ldz (Route53 hosted zone +
-    # DNS-validated ACM cert). If absent, ALB creation stalls.
-    # Track via cross-repo/fyi issue on ldz side.
-    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:eu-central-1:251774439261:certificate/PLACEHOLDER-REPLACE-WITH-LDZ-ACM
+    # ACM certificate for `aegis-api.staging.binhsu.org`. Materialized
+    # by ldz on 2026-04-24 via baseline workflow run 24894738583
+    # (closes ldz #101 + aegis-core #50). DNS validation ISSUED via
+    # Route53 zone `staging.binhsu.org`. Cert region eu-central-1
+    # (regional ACM for ALB per ldz ADR-019's CloudFront-ACM-us-east-1
+    # vs ALB-ACM-regional split).
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:eu-central-1:251774439261:certificate/208f2377-0326-4823-bbbe-e3dff94678ef
     # Healthcheck path for ALB target group probing.
     alb.ingress.kubernetes.io/healthcheck-path: /healthz
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"


### PR DESCRIPTION
Picks up [ldz's 2026-04-24 cold-apply outputs](https://github.com/BinHsu/aegis-core/issues/76#issuecomment-4313057xxx). **Closes [aegis-core #50](https://github.com/BinHsu/aegis-core/issues/50)** by replacing the `PLACEHOLDER-REPLACE-WITH-LDZ-ACM` stub in `apps/staging/aegis-gateway/ingress.yaml` with the real cert ARN from [ldz #101](https://github.com/BinHsu/aegis-aws-landing-zone/issues/101). Adds 4 build-time Vite env vars to `release-staging-frontend.yml` so cloud SPA builds drive the real Cognito Hosted UI per ADR-0034 §D2 — Pool ID + Client ID + Issuer URL + redirect URLs from the [ldz #76 reply](https://github.com/BinHsu/aegis-core/issues/76). Hard-coded rather than `vars.*` because all four values carry `lifecycle.prevent_destroy = true` on ldz side and none are secrets (Cognito Client IDs are public by design — visible in every browser network panel). Gitleaks heuristic false-positive on the Client ID entropy is suppressed via inline `gitleaks:allow` annotation. LOCAL mode untouched.