### PR TITLE
fix(ci): nightly-cognito SSM read fails loud, points at ldz#153

### DIFF
--- a/.github/workflows/nightly-cognito-integration.yml
+++ b/.github/workflows/nightly-cognito-integration.yml
@@ -83,16 +83,36 @@ jobs:
         id: ssm
         run: |
           set -euo pipefail
+          # Capture into local vars first so `set -e` actually propagates
+          # the AWS CLI exit code (it does NOT propagate cleanly out of
+          # `echo "X=$(aws ssm ...)" >> $GITHUB_ENV` — `>> $GITHUB_ENV`
+          # also doesn't set the current shell, which is the second half
+          # of the trap). Targeted annotation on ParameterNotFound points
+          # operators at the canonical cross-repo issue rather than
+          # surfacing as an `unbound variable` red herring.
           read_param() {
-            aws ssm get-parameter \
-              --name "$1" \
-              --query 'Parameter.Value' \
-              --output text
+            local name=$1
+            local value
+            if ! value=$(aws ssm get-parameter \
+                --name "$name" \
+                --query 'Parameter.Value' \
+                --output text 2>&1); then
+              echo "::error title=Cognito SSM PS missing::Parameter ${name} not readable. Most likely cause: SaaS-credential SSM PS wiped by an LDZ workload teardown. Tracked in https://github.com/BinHsu/aegis-aws-landing-zone/issues/153 (Option B persistent-layer relocation). Hold the workflow until that issue's fix lands."
+              echo "aws ssm get-parameter raw output:" >&2
+              echo "${value}" >&2
+              exit 1
+            fi
+            printf '%s' "$value"
           }
-          echo "AEGIS_COGNITO_USER_POOL_ID=$(read_param /aegis/staging/cognito/user-pool-id)" >> "$GITHUB_ENV"
-          echo "AEGIS_COGNITO_APP_CLIENT_ID=$(read_param /aegis/staging/cognito/app-client-id)" >> "$GITHUB_ENV"
-          echo "AEGIS_COGNITO_ISSUER_URL=$(read_param /aegis/staging/cognito/issuer-url)" >> "$GITHUB_ENV"
-          echo "::add-mask::$AEGIS_COGNITO_APP_CLIENT_ID"
+          POOL_ID=$(read_param /aegis/staging/cognito/user-pool-id)
+          CLIENT_ID=$(read_param /aegis/staging/cognito/app-client-id)
+          ISSUER=$(read_param /aegis/staging/cognito/issuer-url)
+          echo "::add-mask::$CLIENT_ID"
+          {
+            echo "AEGIS_COGNITO_USER_POOL_ID=$POOL_ID"
+            echo "AEGIS_COGNITO_APP_CLIENT_ID=$CLIENT_ID"
+            echo "AEGIS_COGNITO_ISSUER_URL=$ISSUER"
+          } >> "$GITHUB_ENV"
           echo "Cognito IDs loaded into env for bazel test."
 
       # Bazel test target. env_inherit on auth_test forwards all the


### PR DESCRIPTION
## Summary

- Today's 03:00 UTC nightly run [24923206034](https://github.com/BinHsu/aegis-core/actions/runs/24923206034) failed with `AEGIS_COGNITO_APP_CLIENT_ID: unbound variable` — a red herring. Real cause: an LDZ workload teardown wiped the three `/aegis/staging/cognito/*` SSM parameters; tracked cross-repo in [ldz#153](https://github.com/BinHsu/aegis-aws-landing-zone/issues/153) (Option B persistent-layer relocation, scope expansion to Cognito requested in [ldz#153 reply](https://github.com/BinHsu/aegis-aws-landing-zone/issues/153#issuecomment-4318169695)).
- Two latent bugs in the original SSM read step compounded the fault: (1) `set -e` does not propagate cleanly out of `$(aws ssm ...)` captured into a string assigned to `echo`'s argument, so the AWS CLI's non-zero exit on `ParameterNotFound` was silently dropped; (2) `>> $GITHUB_ENV` does NOT set the variable in the current shell, so the subsequent `echo "::add-mask::$AEGIS_COGNITO_APP_CLIENT_ID"` always dereferenced an unbound name and would have failed even on the green path.
- Refactor: capture each parameter into a local variable, explicitly check the AWS CLI exit code, and emit a targeted `::error title=Cognito SSM PS missing::` annotation that names ldz#153 as the canonical cross-repo tracker. Add-mask now references the local variable.

## Test plan

- [ ] `gh workflow run nightly-cognito-integration.yml` after ldz#153's persistent-layer relocation lands and the SSM PS are repopulated → expect green
- [ ] Until then, a `workflow_dispatch` re-run will fail at the SSM read step with the new annotation, verifying the loud-fail path
- [x] Pre-commit hooks pass locally (yaml lint, conventional commit)
- [ ] CI on this PR passes (lint + bazel unit + scanners)

🤖 Generated with [Claude Code](https://claude.com/claude-code)