### PR TITLE
feat(phase-4c): activate post-deploy E2E nightly via vars.FRONTEND_DOMAIN

### DIFF
--- a/.github/workflows/postdeploy-e2e.yml
+++ b/.github/workflows/postdeploy-e2e.yml
@@ -14,13 +14,13 @@ name: Post-deploy E2E smoke
 #
 # Gating:
 #
-# The workflow is committed now (Phase 4c slice) but runs as a no-op
-# when the `AEGIS_POSTDEPLOY_URL` repository secret is unset — that
-# matches the present state where ldz's staging cluster is torn down
-# (see `project_ldz_teardown_state.md` in the operator's notes).
-# When ldz cold-starts and `aegis-app.staging.binhsu.org` comes back
-# online, an operator sets the secret and the cron flips from "skip"
-# to "run" automatically.
+# Driven by the existing `vars.FRONTEND_DOMAIN` repository variable
+# (provisioned in Phase 4a, documented in
+# `docs/runbooks/fork-and-self-deploy.md`). The frontend is served by
+# S3 + CloudFront per ADR-0027 — independent of the EKS workload-tier
+# lifecycle, so this nightly runs even while ldz's cluster is torn
+# down. Forks that haven't populated FRONTEND_DOMAIN see the job
+# skip cleanly with operator guidance pointing back at the runbook.
 #
 # Why nightly (not per-commit): post-deploy E2E tests the *deployed*
 # surface, not the pre-merge code. Running it per-commit would test
@@ -56,18 +56,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Short-circuit if AEGIS_POSTDEPLOY_URL unset
+      - name: Short-circuit if FRONTEND_DOMAIN unset
         id: gate
         env:
-          POSTDEPLOY_URL: ${{ secrets.AEGIS_POSTDEPLOY_URL }}
+          FRONTEND_DOMAIN: ${{ vars.FRONTEND_DOMAIN }}
         run: |
-          if [ -z "${POSTDEPLOY_URL:-}" ]; then
-            echo "AEGIS_POSTDEPLOY_URL secret is unset — skipping."
-            echo "Set it to the staging URL (e.g. https://aegis-app.staging.binhsu.org)"
-            echo "on the repository's Secrets page to enable the real run."
+          if [ -z "${FRONTEND_DOMAIN:-}" ]; then
+            echo "vars.FRONTEND_DOMAIN unset — skipping (fork-friendly default)."
+            echo "Set repository variable FRONTEND_DOMAIN to your staging frontend"
+            echo "host (e.g. aegis-app.staging.example.com) per"
+            echo "docs/runbooks/fork-and-self-deploy.md to enable the real run."
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           else
             echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "url=https://${FRONTEND_DOMAIN}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install frontend deps
@@ -81,7 +83,7 @@ jobs:
       - name: Run post-deploy spec
         if: steps.gate.outputs.should_run == 'true'
         env:
-          AEGIS_POSTDEPLOY_URL: ${{ secrets.AEGIS_POSTDEPLOY_URL }}
+          AEGIS_POSTDEPLOY_URL: ${{ steps.gate.outputs.url }}
           # Forward CI=true so the Playwright config applies its
           # retry=1 + github-reporter posture.
           CI: "true"


### PR DESCRIPTION
## Summary

- The post-deploy E2E workflow shipped in PR #85 was gated on the `AEGIS_POSTDEPLOY_URL` repository secret, which was never set — so today the nightly cron silently skips and verifies nothing.
- The SPA at `aegis-app.staging.binhsu.org` is on S3 + CloudFront per ADR-0027 and is independent of the EKS workload-tier lifecycle. It has been live throughout the LDZ teardown window (verified `HTTP 200` from `https://aegis-app.staging.binhsu.org/` today). Only the gating shape was holding the nightly back.
- Switch the gate to `vars.FRONTEND_DOMAIN`, which is already provisioned in Phase 4a's GH-Variables suite (per Slice 4a-5+ runbook) and points at the live staging host. The Playwright spec's `AEGIS_POSTDEPLOY_URL` env contract is preserved — the workflow now constructs the URL from `FRONTEND_DOMAIN` and passes it through under the same env name.

## Test plan

- [x] Pre-commit hooks pass locally (yaml lint, conventional commit)
- [ ] CI on this PR passes (lint + bazel unit + scanners)
- [ ] First nightly run at 03:00 UTC after merge exercises the 3 smoke specs (landing renders, `/host` CTA visible, `/view` bad-token error path) against the live staging frontend — natural verification, no manual `workflow_dispatch` needed
- [ ] Cold-apply (whenever ldz schedules it) doubles as a re-verification window

## Notes

- Side benefit: a public URL no longer rides through Secrets storage. Phase 4a pattern: GH Variables for public config, GH Secrets only for credentials.
- Forks inherit the same shape: set `FRONTEND_DOMAIN`, nightly flips from skip to run. No new variable introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)