### PR TITLE
fix(ci): add --with-decryption to nightly-cognito SSM read

### DIFF
--- a/.github/workflows/nightly-cognito-integration.yml
+++ b/.github/workflows/nightly-cognito-integration.yml
@@ -83,21 +83,33 @@ jobs:
         id: ssm
         run: |
           set -euo pipefail
+          # The Cognito SSM parameters are stored as `SecureString` (KMS
+          # encrypted under alias/aegis-staging-secrets — see the IAM
+          # contract above). Without `--with-decryption` the CLI returns
+          # the encrypted ciphertext, which then sails through every
+          # downstream check (it is, technically, a non-empty string)
+          # and only fails much later when AWS rejects the ciphertext as
+          # a User Pool ID — surfacing as a misleading
+          # `AccessDeniedException` against a ciphertext-shaped resource
+          # ARN. Decrypt at read time so all downstream callers see
+          # plaintext.
+          #
           # Capture into local vars first so `set -e` actually propagates
           # the AWS CLI exit code (it does NOT propagate cleanly out of
           # `echo "X=$(aws ssm ...)" >> $GITHUB_ENV` — `>> $GITHUB_ENV`
           # also doesn't set the current shell, which is the second half
-          # of the trap). Targeted annotation on ParameterNotFound points
-          # operators at the canonical cross-repo issue rather than
-          # surfacing as an `unbound variable` red herring.
+          # of the trap). Targeted annotation on read failure points
+          # operators at the most likely buckets without prejudging which
+          # one fired.
           read_param() {
             local name=$1
             local value
             if ! value=$(aws ssm get-parameter \
                 --name "$name" \
+                --with-decryption \
                 --query 'Parameter.Value' \
                 --output text 2>&1); then
-              echo "::error title=Cognito SSM PS missing::Parameter ${name} not readable. Most likely cause: SaaS-credential SSM PS wiped by an LDZ workload teardown. Tracked in https://github.com/BinHsu/aegis-aws-landing-zone/issues/153 (Option B persistent-layer relocation). Hold the workflow until that issue's fix lands."
+              echo "::error title=Cognito SSM PS read failed::Parameter ${name} not readable. Likely buckets: (1) parameter destroyed (check ldz teardown logs); (2) KMS Decrypt denied on alias/aegis-staging-secrets (check IAM policy on the integration role); (3) STS role assumption returned creds without ssm:GetParameter[s] on this path. Raw CLI output is in the step log above this annotation."
               echo "aws ssm get-parameter raw output:" >&2
               echo "${value}" >&2
               exit 1


### PR DESCRIPTION
## Summary

- **Layer 3** of the nightly-cognito-integration workflow's bug onion. PR #95 fixed Layers 1 + 2 (bash `set -e` doesn't propagate out of `$(...)` capture; `>> $GITHUB_ENV` doesn't populate the current shell). Manual re-run after #95 exposed the next layer.
- The Cognito SSM parameters are `SecureString` (the IAM contract block above the step already implied this — it grants `kms:Decrypt` on `alias/aegis-staging-secrets`, which would be unnecessary for plain `String`). Without `--with-decryption` the CLI returns KMS ciphertext that is, by shape, a non-empty string and sails through `set -e` / `set -u` clean. Failure surfaces much later as `AccessDeniedException` against a ciphertext-shaped User Pool ARN — see [run 24931194391](https://github.com/BinHsu/aegis-core/actions/runs/24931194391) test log: `arn:aws:cognito-idp:eu-central-1:251774439261:userpool/AQICAHg86Tae...` (the `AQICAHg86...` tail is the KMS envelope).
- This morning's diagnosis chased a SSM-wiped-by-teardown narrative without verifying SSM state. Hard evidence from ldz (`aws ssm describe-parameters` listing all 5 cognito SSM PS intact, on [ldz#153 reply 2026-04-25 12:40Z](https://github.com/BinHsu/aegis-aws-landing-zone/issues/153#issuecomment-4319614907)) reset the framing: SSM was always there; we were reading ciphertext.

## Test plan

- [x] Pre-commit hooks pass locally (yaml lint, conventional commit)
- [ ] CI on this PR passes (lint + bazel unit + scanners — same posture as PR #95 since the change is also workflow-only)
- [ ] After merge, manual `gh workflow run nightly-cognito-integration.yml` exercises the live Cognito pool end-to-end and validates Layer 3 was the last layer

## Notes

- Annotation rewritten to enumerate three failure buckets (parameter destroyed / KMS denied / role scope gap) instead of pre-attributing to ldz teardown. The morning's prejudgment-as-text contributed real cross-repo coordination noise; the new shape stays neutral until evidence picks one.
- Postmortem covering all three layers + the misdiagnosis cycle lands separately as Incident 16 per Rule 7 once nightly runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)