### PR TITLE
ci(security): SHA-pin gitleaks-action to v2.3.9

### DIFF
--- a/.github/workflows/ci-baseline.yml
+++ b/.github/workflows/ci-baseline.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- SHA-pin the last residual tag-pinned third-party Action in this repo
- `ci-baseline.yml:57` `gitleaks/gitleaks-action@v2` → `@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9`
- Brings gitleaks-action in line with the existing SHA-pin posture for `aws-actions/*`, `anchore/sbom-action`, `sigstore/cosign-installer`, `aquasecurity/trivy-action`, `actions/attest-build-provenance`

## Why
Audit-driven cleanup surfaced via cross-repo issue #114 (LinkedIn Post 3 review on supply-chain attack surface). Tag pins on third-party Actions are mutable; SHA pins are not. The other six third-party Actions were already SHA-pinned; gitleaks-action was the outlier.

## SHA verification
```
$ gh api repos/gitleaks/gitleaks-action/releases/latest --jq '.tag_name'
"v2.3.9"
$ gh api repos/gitleaks/gitleaks-action/git/refs/tags/v2.3.9 --jq '.object.sha'
"ff98106e4c7b2bc287b24eaf42907196329070c7"
```

Lightweight tag (`object.type: "commit"`), so the SHA is the commit SHA — directly usable as an immutable pin.

## Test plan
- [ ] CI Baseline workflow runs with the new SHA (Gitleaks job included) — direct functional validation that the pinned SHA is a working version of the Action

## Out of scope
- `allowed_actions: "all"` → `selected` (allowlist mode) — info item from #114, decision-deferred (parallel posture with ldz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)