### PR TITLE
chore(namespace): aegis-core internal refs after deploy rename (Rule 11)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,7 +35,7 @@ flowchart LR
     Staff -->|"WebRTC audio<br/>(single mixed track)"| LB["ALB / NGINX Ingress<br/>(session-affinity cookie)"]
     LB --> GW
 
-    subgraph EKSNamespace["EKS namespace: aegis-audio (Kyverno: no PVC, no hostPath)"]
+    subgraph EKSNamespace["EKS namespace: aegis-core (Kyverno: no PVC, no hostPath)"]
         direction TB
         GW["Go Gateway pod<br/>• Pion WebRTC termination<br/>• JWT viewer-token validation<br/>• Per-session fan-out channel<br/>• ControlEvent PAUSE/RESUME/END"]
         ENG["C++ Engine pod<br/>• whisper.cpp large-v3-turbo Q4<br/>• anonymous speaker diarization<br/>• question detection<br/>• RAG query (vector DB client)<br/>• ResourceBudget fail-fast"]

--- a/docs/adr/0017-gateway-engine-topology.md
+++ b/docs/adr/0017-gateway-engine-topology.md
@@ -52,7 +52,7 @@ layer.**
 - Engine dial uses gRPC's built-in client-side load-balancing.
   `AEGIS_ENGINE_ADDR` can be any resolver-understandable target:
   - `localhost:50051` — single engine (Phase 2 local).
-  - `dns:///engine.aegis.svc.cluster.local:50051` — Kubernetes
+  - `dns:///aegis-core-engine.aegis-core.svc.cluster.local:50051` — Kubernetes
     Headless Service resolving to N pod IPs; gRPC round-robin
     picks one per new `StreamTranscribe` stream (Phase 4+ cloud).
   Code always registers `"loadBalancingConfig":[{"round_robin":{}}]`

--- a/docs/adr/0031-mtls-without-service-mesh.md
+++ b/docs/adr/0031-mtls-without-service-mesh.md
@@ -35,8 +35,8 @@ Service mesh's design payoff scales roughly with `O(service-count × interaction
 1. **PKI root** — cert-manager `ClusterIssuer` using a private CA rooted in AWS Private CA (Phase 4c+ ldz-provisioned) OR a cert-manager-managed self-signed intermediate for Phase 4c staging. The Phase 4c-tier decision is intentionally the lightweight self-signed intermediate; migrating to AWS Private CA is a Certificate-CR backend swap, no application change.
 
 2. **Per-workload identity** — each Deployment's pods mount a `Certificate` CR output Secret:
-    - `aegis-core-gateway.aegis.svc.cluster.local` + `aegis-core-gateway.aegis.svc` + `aegis-core-gateway.aegis`
-    - `aegis-core-engine.aegis.svc.cluster.local` + `aegis-core-engine.aegis.svc` + `aegis-core-engine.aegis`
+    - `aegis-core-gateway.aegis-core.svc.cluster.local` + `aegis-core-gateway.aegis-core.svc` + `aegis-core-gateway.aegis-core`
+    - `aegis-core-engine.aegis-core.svc.cluster.local` + `aegis-core-engine.aegis-core.svc` + `aegis-core-engine.aegis-core`
     - Kubernetes DNS names in SANs; K8s `ServiceAccount` name carried in the CN for audit correlation
 
 3. **Rotation** — cert-manager renews certs automatically at 2/3 of their lifetime (default 90d cert → renew at 60d). The underlying `Secret` updates in place. Workloads read from mounted files via:

--- a/gateway_go/cmd/gateway/main.go
+++ b/gateway_go/cmd/gateway/main.go
@@ -217,7 +217,7 @@ func main() {
 	// N:N-readiness. When `engineAddr` is a single host:port (Phase 2
 	// local demo), round_robin is a no-op — there's one endpoint to
 	// pick from. When Phase 4+ Cloud deployment points at a resolver
-	// target like `dns:///engine.aegis.svc.cluster.local:50051`
+	// target like `dns:///aegis-core-engine.aegis-core.svc.cluster.local:50051`
 	// (Kubernetes Headless Service), gRPC's DNS resolver expands to
 	// N pod IPs and round-robin picks one per new StreamTranscribe
 	// stream. Each bidi stream is then automatically session-pinned


### PR DESCRIPTION
## Summary

Aligns this repo's docs + code comments with the new `aegis-core`
namespace landed in `aegis-core-deploy` (commit 3628669).

## Files

- `ARCHITECTURE.md` — EKS namespace diagram label
- `docs/adr/0031-mtls-without-service-mesh.md` — mTLS SAN list (**load-bearing** — cert-manager Certificate CRs issue these SANs; mismatch breaks mTLS handshake)
- `docs/adr/0017-gateway-engine-topology.md` — resolver-target example
- `gateway_go/cmd/gateway/main.go` — code comment example

## Why

CLAUDE.md Rule 11 — per-repo K8s resources must carry the full owning-repo
name. The bare `aegis` namespace was a violation; renamed to `aegis-core`
in the deploy repo. This PR closes the documentation drift.

## Risk

Doc-only + one Go code comment. No build/test surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)