### PR TITLE
ci: raise Bazel unit-tests timeout 30→45 — cold ggml build hit the wall

### DIFF
--- a/.github/workflows/ci-baseline.yml
+++ b/.github/workflows/ci-baseline.yml
@@ -129,7 +129,8 @@ jobs:
   bazel-unit-tests:
     name: Bazel unit tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # cold ggml builds run 17-28min; 30 was too tight (run 27428960657 hit the wall 2026-06-12)
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

Run [27428960657](https://github.com/BinHsu/aegis-core/actions/runs/27428960657) was cancelled at exactly 30:00 on 2026-06-12 — a cold-cache hit. The ggml engine + gateway OCI cold build historically takes **17–28 min**, which means the 30-min ceiling is a reliable source of WS1 flakes on any cold runner.

## Change

`.github/workflows/ci-baseline.yml` — `bazel-unit-tests` job only:

```
timeout-minutes: 30  →  45
```

The `frontend-e2e-smoke` job's 15-min timeout is untouched.

A one-line comment is added above `timeout-minutes` documenting the rationale and the incident run so the next reviewer understands the number isn't arbitrary.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses cleanly
- [x] `grep -n timeout-minutes ci-baseline.yml` — confirms only the Bazel job changed (line 133 → 45; line 334 stays at 15)
- [ ] CI run on this PR — verify the Bazel job reaches completion rather than hitting the 30-min wall

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to allow additional time for test execution during continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->