### PR TITLE
fix(engine): make the engine image actually runnable (WS2-2) — distroless_cc/debian13 + manifest + GGML_NATIVE=OFF

### DIFF
--- a/.github/workflows/release-onprem-image.yml
+++ b/.github/workflows/release-onprem-image.yml
@@ -15,12 +15,21 @@ name: Release on-prem image to GHCR
 #
 # WHY a native arm64 runner:
 #   The local Talos cluster runs on apple/container = linux/arm64. An amd64
-#   image (the ubuntu-latest default) would not run there. ubuntu-24.04-arm is
+#   image (the ubuntu-latest default) would not run there. ubuntu-22.04-arm is
 #   GitHub's free arm64 Linux runner for public repos. local_config_cc
 #   auto-detects the runner's arm64 GCC — no toolchain / sysroot setup, no
 #   BUILD changes. This is also why the engine build belongs in CI, not on the
 #   16GB dev host: the grpc + BoringSSL + whisper.cpp/ggml/llama.cpp link line
 #   needs more RAM than that host can spare for a build VM (de-risked 2026-06-16).
+#
+# WHY 22.04, not 24.04 (resolved 2026-06-16, WS2-2 live verify):
+#   The runtime base is distroless cc-debian12 (Debian 12, glibc 2.36). A binary
+#   built on ubuntu-24.04 (glibc 2.39, GCC 13 / GLIBCXX_3.4.32) references
+#   symbol versions newer than Debian 12 provides — the engine crashed at
+#   startup with `GLIBC_2.38 not found` / `GLIBCXX_3.4.32 not found`. glibc is
+#   forward-compatible, not backward: build against an OLDER glibc than the
+#   runtime base. ubuntu-22.04 ships glibc 2.35 (<= 2.36) and a libstdc++ no
+#   newer than Debian 12's, so the binary runs. Keep build glibc <= runtime base.
 #
 # Manual trigger only for now (local-first; the operator pulls on demand). A
 # push trigger can be added once the WS2 on-prem flow stabilises.
@@ -47,7 +56,7 @@ env:
 jobs:
   push-onprem-image:
     name: Build + push core images to GHCR (linux/arm64)
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/release-onprem-image.yml
+++ b/.github/workflows/release-onprem-image.yml
@@ -15,21 +15,21 @@ name: Release on-prem image to GHCR
 #
 # WHY a native arm64 runner:
 #   The local Talos cluster runs on apple/container = linux/arm64. An amd64
-#   image (the ubuntu-latest default) would not run there. ubuntu-22.04-arm is
+#   image (the ubuntu-latest default) would not run there. ubuntu-24.04-arm is
 #   GitHub's free arm64 Linux runner for public repos. local_config_cc
 #   auto-detects the runner's arm64 GCC — no toolchain / sysroot setup, no
 #   BUILD changes. This is also why the engine build belongs in CI, not on the
 #   16GB dev host: the grpc + BoringSSL + whisper.cpp/ggml/llama.cpp link line
 #   needs more RAM than that host can spare for a build VM (de-risked 2026-06-16).
 #
-# WHY 22.04, not 24.04 (resolved 2026-06-16, WS2-2 live verify):
-#   The runtime base is distroless cc-debian12 (Debian 12, glibc 2.36). A binary
-#   built on ubuntu-24.04 (glibc 2.39, GCC 13 / GLIBCXX_3.4.32) references
-#   symbol versions newer than Debian 12 provides — the engine crashed at
-#   startup with `GLIBC_2.38 not found` / `GLIBCXX_3.4.32 not found`. glibc is
-#   forward-compatible, not backward: build against an OLDER glibc than the
-#   runtime base. ubuntu-22.04 ships glibc 2.35 (<= 2.36) and a libstdc++ no
-#   newer than Debian 12's, so the binary runs. Keep build glibc <= runtime base.
+# RUNTIME-BASE glibc must be >= the build glibc (resolved 2026-06-16, WS2-2):
+#   The engine binary is dynamically linked and local_config_cc is non-hermetic,
+#   so it inherits the runner's glibc (ubuntu-24.04-arm = glibc 2.39, GCC 13 /
+#   GLIBCXX_3.4.32). glibc is forward-compatible, not backward — the runtime
+#   base must therefore ship glibc >= 2.39. distroless cc-debian12 (glibc 2.36)
+#   was too old: the engine crashed at startup with `GLIBC_2.38 not found` /
+#   `GLIBCXX_3.4.32 not found`. The base is now cc-debian13 (Debian 13, glibc
+#   2.41 / GCC 14) — see packaging/engine/BUILD.bazel + MODULE.bazel.
 #
 # Manual trigger only for now (local-first; the operator pulls on demand). A
 # push trigger can be added once the WS2 on-prem flow stabilises.
@@ -56,7 +56,7 @@ env:
 jobs:
   push-onprem-image:
     name: Build + push core images to GHCR (linux/arm64)
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -295,6 +295,33 @@ use_repo(
     "distroless_static_linux_arm64_v8",
 )
 
+# Distroless cc-debian12:nonroot — the base for the C++ ENGINE image (the Go
+# gateway stays on distroless_static). The engine's link line (grpc++ + BoringSSL
+# + protobuf + whisper.cpp/ggml/llama.cpp via rules_foreign_cc CMake + libopus)
+# produces a DYNAMICALLY-linked binary — the CMake recipes don't honour -static,
+# so the binary needs an ELF loader + glibc + libstdc++/libgcc_s at runtime.
+# distroless_static ships none of those: the engine image built on it failed at
+# `exec /usr/local/bin/engine: no such file or directory` (missing PT_INTERP)
+# the first time it was actually run (WS2-2 live verify, 2026-06-16). cc-debian12
+# is Google's designated base for dynamically-linked C/C++ — it adds the loader,
+# glibc, libstdc++, and libgcc_s that `base-debian12` (glibc only) still lacks.
+# Pinned by manifest-list digest (resolved 2026-06-16); re-pin on bump.
+oci.pull(
+    name = "distroless_cc",
+    digest = "sha256:b0ae8e989418b458e0f25489bc3be523718938a2b70864cc0f6a00af1ddbd985",
+    image = "gcr.io/distroless/cc-debian12",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64/v8",
+    ],
+)
+use_repo(
+    oci,
+    "distroless_cc",
+    "distroless_cc_linux_amd64",
+    "distroless_cc_linux_arm64_v8",
+)
+
 # -----------------------------------------------------------------------------
 # Phase 4+ dependencies (added as each component comes online):
 #

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -295,21 +295,28 @@ use_repo(
     "distroless_static_linux_arm64_v8",
 )
 
-# Distroless cc-debian12:nonroot — the base for the C++ ENGINE image (the Go
+# Distroless cc-debian13:nonroot — the base for the C++ ENGINE image (the Go
 # gateway stays on distroless_static). The engine's link line (grpc++ + BoringSSL
 # + protobuf + whisper.cpp/ggml/llama.cpp via rules_foreign_cc CMake + libopus)
 # produces a DYNAMICALLY-linked binary — the CMake recipes don't honour -static,
 # so the binary needs an ELF loader + glibc + libstdc++/libgcc_s at runtime.
 # distroless_static ships none of those: the engine image built on it failed at
 # `exec /usr/local/bin/engine: no such file or directory` (missing PT_INTERP)
-# the first time it was actually run (WS2-2 live verify, 2026-06-16). cc-debian12
-# is Google's designated base for dynamically-linked C/C++ — it adds the loader,
-# glibc, libstdc++, and libgcc_s that `base-debian12` (glibc only) still lacks.
-# Pinned by manifest-list digest (resolved 2026-06-16); re-pin on bump.
+# the first time it was actually run (WS2-2 live verify, 2026-06-16). cc-* is
+# Google's designated base for dynamically-linked C/C++ (loader + glibc +
+# libstdc++ + libgcc_s; base-* has glibc only).
+#
+# WHY debian13, not debian12: local_config_cc is non-hermetic, so the binary
+# inherits the CI runner's glibc (ubuntu-24.04-arm = glibc 2.39). glibc is
+# forward-compatible only — the runtime base must be >= the build glibc.
+# cc-debian12 (glibc 2.36) was too old (`GLIBC_2.38 not found` at startup);
+# cc-debian13 ships glibc 2.41 / GCC 14 libstdc++. Pinned by manifest-list
+# digest (resolved 2026-06-16); re-pin on bump. If the build runner ever moves
+# to a newer glibc than debian13, bump this base in lockstep.
 oci.pull(
     name = "distroless_cc",
-    digest = "sha256:b0ae8e989418b458e0f25489bc3be523718938a2b70864cc0f6a00af1ddbd985",
-    image = "gcr.io/distroless/cc-debian12",
+    digest = "sha256:d3cda6e91129130d7229a1806b6a73d292ef245ab032da7851907798024cefba",
+    image = "gcr.io/distroless/cc-debian13",
     platforms = [
         "linux/amd64",
         "linux/arm64/v8",

--- a/docs/adr/0025-oci-packaging-strategy.md
+++ b/docs/adr/0025-oci-packaging-strategy.md
@@ -193,12 +193,20 @@ at `exec /usr/local/bin/engine: no such file or directory`. The 79 MB binary
 was present and arm64-correct; ENOENT-on-exec means a missing ELF interpreter
 — i.e. the binary is dynamically linked (rules_foreign_cc CMake deps don't
 honour -static, as the fork-point comment anticipated) and `static-debian12`
-ships no loader. The fix is `cc-debian12`, NOT the `base-debian12` the
-fork-point originally named: a dynamic C++ binary also needs `libstdc++` +
-`libgcc_s`, which `base` (glibc only) lacks; `cc` is Google's designated base
-for dynamically-linked C/C++. The gateway (Go, genuinely static) stays on
-`static-debian12`. Net cost of the lost bet: one extra CI build cycle, exactly
-as this decision's "cost of trying-and-failing" line predicted.
+ships no loader. The fix is `cc-debian13`, NOT the `base-debian12` the
+fork-point originally named. Two corrections: (1) a dynamic C++ binary needs
+`libstdc++` + `libgcc_s`, which `base` (glibc only) lacks — `cc` is Google's
+designated base for dynamically-linked C/C++; (2) the cc variant must be new
+enough. `local_config_cc` is non-hermetic, so the binary inherits the CI
+runner's glibc (ubuntu-24.04-arm = glibc 2.39). glibc is forward-compatible
+only, so `cc-debian12` (glibc 2.36) still failed with `GLIBC_2.38 not found`;
+`cc-debian13` (glibc 2.41 / GCC 14) satisfies it. Rule: runtime base glibc >=
+build-runner glibc. (The non-hermetic cache makes this a property of the runner,
+not the source — a Bazel remote-cache hit reused the 24.04-built objects across
+runner versions, so "build on an older runner" did NOT work; moving the base
+forward did.) The gateway (Go, genuinely static) stays on `static-debian12`.
+Net cost of the lost bet: a couple of CI build cycles, as this decision's "cost
+of trying-and-failing" line predicted.
 
 Original reasoning (kept for the trail):
 - The base image was already pulled in `MODULE.bazel` for the gateway

--- a/docs/adr/0025-oci-packaging-strategy.md
+++ b/docs/adr/0025-oci-packaging-strategy.md
@@ -72,7 +72,7 @@ no Dockerfile-equivalent `useradd` action is required.
 | 4a-1 (this ADR) | `rules_oci` wiring + Go gateway image; local-only, no push | `aegis-core-gateway` |
 | 4a-2 ✅ | SBOM via Syft (CycloneDX) — `anchore/sbom-action` SHA-pinned, runs after smoke step against the loaded `aegis-core-gateway:dev-local` image; output `gateway.sbom.cdx.json` uploaded as workflow artifact | (no new image) |
 | 4a-3 ✅ | GitHub Actions ECR push via OIDC role from ldz #74. Dedicated `release-staging-image.yml` workflow on `push: branches: [main]` (PR builds don't push). `oci_push` Bazel target consumes ECR auth from `aws-actions/amazon-ecr-login`'s populated docker config. Tag: `staging-<git_sha>`. Defense-in-depth re-smoke before push. | (no new image) |
-| 4a-4 ✅ | C++ engine image. Distroless `static-debian12:nonroot` tried first; if engine fails to start in Phase 4c due to missing libc, swap to `@distroless_base` per the fork-point comment in `packaging/engine/BUILD.bazel`. Models mount-at-runtime — storage delivery specced in cross-repo [ldz #82](https://github.com/BinHsu/aegis-aws-landing-zone/issues/82) (ldz picks AWS-side realization). No engine smoke this slice (engine needs model on startup; Phase 4c K8s manifest is the smoke harness). No engine SBOM this slice (deferred until distroless variant proves stable in deployment). | `aegis-core-engine` |
+| 4a-4 ✅ | C++ engine image. Distroless `static-debian12:nonroot` tried first; **RESOLVED 2026-06-16 (WS2-2): flipped to `@distroless_cc`** — the engine binary is dynamically linked and static ships no loader (see §"Slice 4 distroless variant decision"). Models mount-at-runtime — storage delivery specced in cross-repo [ldz #82](https://github.com/BinHsu/aegis-aws-landing-zone/issues/82) (ldz picks AWS-side realization). No engine smoke this slice (engine needs model on startup; Phase 4c K8s manifest is the smoke harness). No engine SBOM this slice (deferred until distroless variant proves stable in deployment). | `aegis-core-engine` |
 | 4a-5 | Frontend image — static asset packaging | `aegis-frontend` |
 | 4b   | Cosign signing + SLSA L3 + Trivy scan; SBOM becomes Cosign attestation (anchore/sbom-action supports natively) | (gates the above) |
 
@@ -186,7 +186,21 @@ ADR sign time and is now resolved (Slice 4, 2026-04-19):
 recorded in `packaging/engine/BUILD.bazel` if linker / runtime
 loader fails.**
 
-Reasoning:
+**RESOLVED 2026-06-16 (WS2-2): the try-static bet lost — engine flipped to
+`@distroless_cc`.** The first time the engine image was actually run (WS2-2
+live verify on local Talos — WS2-1 had only proved the *build*), it failed
+at `exec /usr/local/bin/engine: no such file or directory`. The 79 MB binary
+was present and arm64-correct; ENOENT-on-exec means a missing ELF interpreter
+— i.e. the binary is dynamically linked (rules_foreign_cc CMake deps don't
+honour -static, as the fork-point comment anticipated) and `static-debian12`
+ships no loader. The fix is `cc-debian12`, NOT the `base-debian12` the
+fork-point originally named: a dynamic C++ binary also needs `libstdc++` +
+`libgcc_s`, which `base` (glibc only) lacks; `cc` is Google's designated base
+for dynamically-linked C/C++. The gateway (Go, genuinely static) stays on
+`static-debian12`. Net cost of the lost bet: one extra CI build cycle, exactly
+as this decision's "cost of trying-and-failing" line predicted.
+
+Original reasoning (kept for the trail):
 - The base image was already pulled in `MODULE.bazel` for the gateway
   Slice 1 — zero new `oci.pull` cost to try it for engine.
 - Default Bazel `cc_binary` linkstatic produces a static-leaning ELF;

--- a/engine_cpp/third_party/ggml/ggml.BUILD
+++ b/engine_cpp/third_party/ggml/ggml.BUILD
@@ -27,6 +27,16 @@ cmake(
         "GGML_CUDA": "OFF",
         "GGML_VULKAN": "OFF",
         "GGML_OPENMP": "OFF",
+        # Portable CPU baseline, NOT -mcpu=native. ggml defaults GGML_NATIVE=ON,
+        # which bakes in the BUILD HOST's CPU features. The engine is built on a
+        # GitHub arm64 runner (Ampere/Graviton) but runs on Apple Silicon via
+        # apple/container — a different ARM microarch, so a native build SIGILLs
+        # at the first unsupported instruction during model load (exit 132;
+        # caught WS2-2 live verify 2026-06-16). OFF compiles an armv8-a baseline
+        # that runs on any arm64 (Apple Silicon is a superset). If a perf
+        # baseline ever needs per-host tuning, build per-target — don't ship one
+        # image to heterogeneous CPUs.
+        "GGML_NATIVE": "OFF",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
     },
     lib_source = ":all_srcs",

--- a/engine_cpp/third_party/llama_cpp/llama_cpp.BUILD
+++ b/engine_cpp/third_party/llama_cpp/llama_cpp.BUILD
@@ -32,6 +32,9 @@ cmake(
         "GGML_CUDA": "OFF",
         "GGML_VULKAN": "OFF",
         "GGML_OPENMP": "OFF",
+        # Portable CPU baseline (see ggml.BUILD). GGML_NATIVE=ON would bake in
+        # the CI runner's ARM microarch and SIGILL on the Apple Silicon guest.
+        "GGML_NATIVE": "OFF",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
     },
     # Depend on the ggml cmake target. rules_foreign_cc propagates

--- a/engine_cpp/third_party/whisper_cpp/whisper_cpp.BUILD
+++ b/engine_cpp/third_party/whisper_cpp/whisper_cpp.BUILD
@@ -63,6 +63,9 @@ cmake(
         # Prevention section. Safe to keep aligned with whatever
         # MACOSX_DEPLOYMENT_TARGET Bazel's apple toolchain emits.
         "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
+        # Portable CPU baseline (see ggml.BUILD). GGML_NATIVE=ON would bake in
+        # the CI runner's ARM microarch and SIGILL on the Apple Silicon guest.
+        "GGML_NATIVE": "OFF",
     },
     # Backend selection (metal/cuda flags) is deferred to the consumer
     # wrapper in the root module, which has access to

--- a/models/BUILD.bazel
+++ b/models/BUILD.bazel
@@ -1,0 +1,12 @@
+# Exposes models/manifest.json as a Bazel target so the engine OCI image can
+# bundle it (packaging/engine:manifest_files). The manifest is the integrity
+# contract the engine binary was built against (ADR-0026 CAS preflight) — it
+# ships WITH the binary, not in the model object store: the object store holds
+# the model *files*, the image holds the manifest that lists + SHA-pins them.
+# (Until 2026-06-16 the manifest was not packaged anywhere — the engine FATALed
+# at `cannot load manifest from models/manifest.json` the first time it ran;
+# WS2-2 live verify.)
+exports_files(
+    ["manifest.json"],
+    visibility = ["//visibility:public"],
+)

--- a/packaging/engine/BUILD.bazel
+++ b/packaging/engine/BUILD.bazel
@@ -26,19 +26,25 @@
 #    sysroot for cross-compile, so the right answer is "build on the
 #    correct host", not "block analysis on the wrong host".
 #
-# 2. Trying distroless `static-debian12:nonroot` first (vs `base`).
+# 2. base = "@distroless_cc" (RESOLVED 2026-06-16, WS2-2).
 #    The C++ engine's link line is grpc++ + Abseil + BoringSSL +
 #    protobuf + whisper.cpp/ggml/llama.cpp via rules_foreign_cc CMake
-#    + libopus. Default Bazel cc_binary linkstatic produces a static
-#    binary, but BoringSSL historically uses NSS modules for DNS that
-#    require glibc-with-NSS even when statically linked elsewhere,
-#    and rules_foreign_cc CMake recipes don't always honor -static.
+#    + libopus. The original guess was that cc_binary linkstatic would
+#    yield a fully static binary runnable on `distroless_static`. It does
+#    not: rules_foreign_cc CMake recipes don't honour -static, so the
+#    binary is DYNAMICALLY linked. `distroless_static` ships no ELF loader,
+#    so the image built fine but failed to exec — `exec /usr/local/bin/
+#    engine: no such file or directory` (missing PT_INTERP) — the first
+#    time it was actually run (WS2-2 live verify on local Talos; WS2-1 only
+#    proved the build, never ran it).
 #
-#    If `:image` fails to build because of dynamic-lib references,
-#    swap base = "@distroless_base" (requires adding distroless_base
-#    to MODULE.bazel oci.pull). This BUILD's comment block is the
-#    ground-truth fork point — do NOT silently flip without updating
-#    ADR-0025 §"Slice 4 distroless variant decision".
+#    The fix is `@distroless_cc`, NOT the `@distroless_base` this comment
+#    used to suggest: a dynamically-linked C++ binary needs libstdc++ +
+#    libgcc_s, which `base-debian12` (glibc only) lacks. cc-debian12 is
+#    Google's designated base for dynamically-linked C/C++ (loader + glibc
+#    + libstdc++ + libgcc_s). Pulled in MODULE.bazel. This BUILD's comment
+#    block is the ground-truth fork point — kept in sync with ADR-0025
+#    §"Slice 4 distroless variant decision".
 #
 # 3. Models NOT shipped in image. Engine reads model path via
 #    `AEGIS_MODEL_PATH` env var (`engine_cpp/cmd/engine/main.cc:68-73`)
@@ -123,7 +129,12 @@ pkg_tar(
 
 oci_image(
     name = "image",
-    base = "@distroless_static",
+    # distroless_cc, NOT distroless_static — see comment §2 below and
+    # MODULE.bazel. The engine binary is dynamically linked (CMake deps don't
+    # honour -static); static has no ELF loader, so the image failed to exec
+    # the first time it ran (WS2-2 live verify). cc supplies loader + glibc +
+    # libstdc++/libgcc_s.
+    base = "@distroless_cc",
     entrypoint = ["/usr/local/bin/engine"],
     # Engine listens on :50051 for gRPC (engine_cpp/cmd/engine/main.cc:55).
     # Informational metadata; NetworkPolicy is the actual enforcement

--- a/packaging/engine/BUILD.bazel
+++ b/packaging/engine/BUILD.bazel
@@ -124,11 +124,28 @@ pkg_files(
     prefix = "/usr/local/share/corpora",
 )
 
+# The model manifest (ADR-0026 CAS integrity contract). It ships in the IMAGE
+# because it is versioned WITH the engine binary — the object store / S3 mount
+# holds the model files, the image holds the manifest that lists + SHA-pins
+# them. Placed OUTSIDE /models on purpose: in K8s the engine mounts a volume at
+# /models (emptyDir populated from MinIO on-prem, S3+CSI on AWS), which would
+# shadow anything the image put there. AEGIS_MANIFEST_PATH points the engine
+# here (set in the deploy manifests). Without this the engine FATALs at
+# `cannot load manifest from models/manifest.json` — caught the first time it
+# actually ran (WS2-2 live verify, 2026-06-16).
+pkg_files(
+    name = "manifest_files",
+    srcs = ["//models:manifest.json"],
+    attributes = pkg_attributes(mode = "0644"),
+    prefix = "/usr/local/share/aegis/models",
+)
+
 pkg_tar(
     name = "engine_layer",
     srcs = [
         ":corpus_files",
         ":engine_files",
+        ":manifest_files",
     ],
 )
 

--- a/packaging/engine/BUILD.bazel
+++ b/packaging/engine/BUILD.bazel
@@ -40,11 +40,16 @@
 #
 #    The fix is `@distroless_cc`, NOT the `@distroless_base` this comment
 #    used to suggest: a dynamically-linked C++ binary needs libstdc++ +
-#    libgcc_s, which `base-debian12` (glibc only) lacks. cc-debian12 is
-#    Google's designated base for dynamically-linked C/C++ (loader + glibc
-#    + libstdc++ + libgcc_s). Pulled in MODULE.bazel. This BUILD's comment
-#    block is the ground-truth fork point — kept in sync with ADR-0025
-#    §"Slice 4 distroless variant decision".
+#    libgcc_s, which `base-*` (glibc only) lacks. cc-* is Google's designated
+#    base for dynamically-linked C/C++ (loader + glibc + libstdc++ + libgcc_s).
+#
+#    The cc variant must also be NEW ENOUGH: local_config_cc is non-hermetic,
+#    so the binary inherits the CI runner's glibc (ubuntu-24.04-arm = 2.39).
+#    glibc is forward-compatible only, so cc-debian12 (glibc 2.36) was too old
+#    (`GLIBC_2.38 not found`); the base is cc-debian13 (glibc 2.41). Keep the
+#    runtime base glibc >= the build-runner glibc. Pulled in MODULE.bazel.
+#    This BUILD's comment block is the ground-truth fork point — kept in sync
+#    with ADR-0025 §"Slice 4 distroless variant decision".
 #
 # 3. Models NOT shipped in image. Engine reads model path via
 #    `AEGIS_MODEL_PATH` env var (`engine_cpp/cmd/engine/main.cc:68-73`)


### PR DESCRIPTION
WS2-1 proved `//packaging/engine:image` **builds**; it had never been **run**. WS2-2's live verify on a local Talos cluster (apple/container, arm64) ran it for the first time and peeled five distinct runtime gaps — each fixed here:

| # | Symptom | Root cause | Fix |
|---|---|---|---|
| 1 | `exec /usr/local/bin/engine: no such file or directory` | distroless `static` ships no ELF loader; the binary is dynamically linked (rules_foreign_cc CMake deps don't honour `-static`) | base → `@distroless_cc` |
| 2 | `GLIBC_2.38 not found` / `GLIBCXX_3.4.32 not found` | build glibc 2.39 (ubuntu-24.04-arm) > runtime 2.36 (Debian 12); `local_config_cc` non-hermetic → binary inherits runner glibc | `cc-debian12` → `cc-debian13` (glibc 2.41 / GCC 14) |
| 3 | `cannot load manifest from models/manifest.json: NOT_FOUND` | `engine_layer` never packaged the manifest | `models/BUILD.bazel` exports it; `manifest_files` → image at `/usr/local/share/aegis/models/` |
| 4 | *(engine runs, reads /models)* | — | — |
| 5 | exit 132 (SIGILL), no log | ggml `GGML_NATIVE=ON` baked the CI runner's ARM microarch (Ampere/Graviton); illegal on the Apple Silicon guest | `GGML_NATIVE=OFF` in ggml/whisper/llama (armv8-a baseline) |

The Go gateway (genuinely static) stays on `@distroless_static`. ADR-0025 §"Slice 4 distroless variant decision" records the chain; the `packaging/engine/BUILD.bazel` fork-point comment is kept in sync.

**Rule extracted:** runtime-base glibc ≥ build-runner glibc; never `-mcpu=native` for an image shipped to heterogeneous CPUs.

Verified: engine image pulls + boots past CAS preflight against a MinIO-delivered model on local arm64 Talos (digest from the on-prem CI build; see aegis-platform-aws#46 / ADR-18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed engine runtime initialization failures caused by missing system library dependencies.
  * Enhanced cross-platform hardware compatibility by using portable CPU baselines instead of build-machine-specific features that caused crashes on certain hardware.
  * Engine image now properly includes model manifest for correct runtime operations.

* **Documentation**
  * Updated architecture documentation with resolved packaging strategy decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->