### PR TITLE
feat(ws3): frontend runtime /config.json + CI digest commit-back

### DIFF
--- a/.github/workflows/release-staging-frontend.yml
+++ b/.github/workflows/release-staging-frontend.yml
@@ -128,6 +128,28 @@ jobs:
         # values at build time — see ADR-0027 §"Build-time env injection".
         run: ./tools/scripts/frontend.sh build
 
+      - name: Write runtime config.json (ADR-15)
+        # The SPA reads /config.json at boot and lets it override anything
+        # baked into the bundle (the committed public/config.json ships
+        # LOCAL mode for a fresh clone). This step is the runtime source of
+        # truth for the staging deploy; values mirror the VITE_* env above,
+        # which now serves only as a build-time fallback.
+        run: |
+          set -euxo pipefail
+          cat > frontend_web/dist/config.json <<EOF
+          {
+            "deployMode": "cloud",
+            "gatewayEndpoint": "${VITE_AEGIS_GATEWAY_ENDPOINT}",
+            "cognito": {
+              "authority": "${VITE_AEGIS_COGNITO_AUTHORITY}",
+              "clientId": "${VITE_AEGIS_COGNITO_CLIENT_ID}",
+              "redirectUri": "${VITE_AEGIS_COGNITO_REDIRECT_URI}",
+              "logoutUri": "${VITE_AEGIS_COGNITO_LOGOUT_URI}"
+            }
+          }
+          EOF
+          cat frontend_web/dist/config.json
+
       # OIDC token → STS AssumeRoleWithWebIdentity → temporary creds
       # exposed as env vars for subsequent aws CLI calls.
       - name: Configure AWS credentials (OIDC)
@@ -148,13 +170,18 @@ jobs:
           aws s3 sync frontend_web/dist/ "s3://${FRONTEND_BUCKET}/" \
             --delete \
             --cache-control "public, max-age=31536000, immutable" \
-            --exclude "index.html"
-          # index.html gets a short cache so users see new builds promptly
-          # without waiting for the year-long immutable TTL on the assets
-          # it references.
+            --exclude "index.html" \
+            --exclude "config.json"
+          # index.html + config.json get a short cache so users see new
+          # builds and config changes promptly without waiting for the
+          # year-long immutable TTL on the content-hashed assets.
           aws s3 cp frontend_web/dist/index.html "s3://${FRONTEND_BUCKET}/index.html" \
             --cache-control "public, max-age=60, must-revalidate" \
             --content-type "text/html; charset=utf-8"
+          # config.json is the ADR-15 runtime config — never immutable-cached.
+          aws s3 cp frontend_web/dist/config.json "s3://${FRONTEND_BUCKET}/config.json" \
+            --cache-control "public, max-age=60, must-revalidate" \
+            --content-type "application/json; charset=utf-8"
 
       - name: Invalidate CloudFront edge cache
         run: |

--- a/.github/workflows/release-staging-image.yml
+++ b/.github/workflows/release-staging-image.yml
@@ -69,6 +69,11 @@ jobs:
     name: Push staging gateway image to ECR
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Expose the captured push digests so the bump-image-tag job can pin the
+    # deploy overlay BY DIGEST (ADR-14/17), not by mutable tag.
+    outputs:
+      gateway_digest: ${{ steps.push-gateway.outputs.digest }}
+      engine_digest: ${{ steps.push-engine.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -462,9 +467,12 @@ jobs:
           # NOTE: if gh pr create returns 403, rotate this PAT to add
           # pull-requests: write — the current PAT is contents-only.
           DEPLOY_PAT: ${{ secrets.AEGIS_CORE_DEPLOY_PAT }}
-          # Same SHA the image-build + push steps above tag with:
-          #   gateway -> staging-<sha>      engine -> engine-staging-<sha>
+          # Commit SHA — used for the branch name + commit/PR metadata only.
           RUN_SHA: ${{ github.sha }}
+          # Image DIGESTS captured by the push job. The overlay pins by digest,
+          # not mutable tag (ADR-14/17 "build once, promote by digest").
+          GATEWAY_DIGEST: ${{ needs.push-staging-image.outputs.gateway_digest }}
+          ENGINE_DIGEST: ${{ needs.push-staging-image.outputs.engine_digest }}
         run: |
           set -euo pipefail
 
@@ -480,13 +488,19 @@ jobs:
           echo "::add-mask::${DEPLOY_PAT}"
 
           set -x
-          # The deploy manifests use the SHORT image form
-          # `aegis-core:<tag>` — the registry host is de-hardcoded into the
-          # kustomize overlay (ADR-0036), so the bump rewrites ONLY the tag
-          # and preserves the `staging-` / `engine-staging-` prefix.
           SHORT_SHA="${RUN_SHA:0:12}"
-          GATEWAY_IMG="aegis-core:staging-${RUN_SHA}"
-          ENGINE_IMG="aegis-core:engine-staging-${RUN_SHA}"
+
+          # Pin the staging overlay BY DIGEST (ADR-10/14/17). The deploy repo's
+          # base image fields stay neutral (`aegis-core`); the per-env digest
+          # lives in the overlay's JSON6902 patch FILES. The seed Job carries the
+          # SAME digest as the engine Rollout (ADR-14). The overlay replacement
+          # splices the platform-injected ECR registry in front of the digest.
+          if [ -z "${GATEWAY_DIGEST:-}" ] || [ -z "${ENGINE_DIGEST:-}" ]; then
+            echo "::warning title=Tag bump skipped::push-staging-image did not surface both digests (gateway='${GATEWAY_DIGEST:-}', engine='${ENGINE_DIGEST:-}'). Nothing to pin."
+            exit 0
+          fi
+          GATEWAY_REF="aegis-core@${GATEWAY_DIGEST}"
+          ENGINE_REF="aegis-core@${ENGINE_DIGEST}"
 
           # Shallow-clone the deploy repo via the PAT.
           git clone --depth 1 \
@@ -494,20 +508,13 @@ jobs:
             deploy
           cd deploy
 
-          # yq is preinstalled on ubuntu-latest runners. The `image:` field
-          # is a plain string on the first (only) container of each workload.
-          # All three edits happen before any git op — single atomic commit.
-          yq -i \
-            ".spec.template.spec.containers[0].image = \"${GATEWAY_IMG}\"" \
-            k8s/base/aegis-core-gateway/rollout.yaml
-          yq -i \
-            ".spec.template.spec.containers[0].image = \"${ENGINE_IMG}\"" \
-            k8s/base/aegis-core-engine/rollout.yaml
-          # seed-job.yaml rides the same engine image SHA as the engine
-          # Rollout — the bump keeps the two in lockstep.
-          yq -i \
-            ".spec.template.spec.containers[0].image = \"${ENGINE_IMG}\"" \
-            k8s/base/aegis-core-engine/seed-job.yaml
+          # yq is preinstalled on ubuntu-latest runners. Each digest pin is a
+          # JSON6902 patch file (a one-element list); set [0].value. All edits
+          # happen before any git op — single atomic commit (ADR-14 both-or-neither).
+          yq -i ".[0].value = \"${GATEWAY_REF}\"" k8s/overlays/staging/digest-gateway.yaml
+          yq -i ".[0].value = \"${ENGINE_REF}\""  k8s/overlays/staging/digest-engine.yaml
+          # seed == engine digest (ADR-14, validate.yml Guard C).
+          yq -i ".[0].value = \"${ENGINE_REF}\""  k8s/overlays/staging/digest-seed.yaml
 
           # Idempotency: manifests already at this SHA → nothing to do.
           if git diff --quiet; then
@@ -521,9 +528,12 @@ jobs:
           BRANCH="release/tag-${SHORT_SHA}"
           git checkout -b "${BRANCH}"
           git add -A
-          git commit -m "ci(deploy): bump aegis-core image tags to ${SHORT_SHA}" \
-            -m "Automated by release-staging-image.yml in aegis-core (ADR-0036)." \
-            -m "Images built and pushed from aegis-core commit ${RUN_SHA}."
+          git commit -m "ci(deploy): pin aegis-core staging digests (${SHORT_SHA})" \
+            -m "Automated by release-staging-image.yml in aegis-core (ADR-10/14/17)." \
+            -m "Pins the staging overlay by digest (gateway + engine + seed, atomic):" \
+            -m "  gateway: ${GATEWAY_REF}" \
+            -m "  engine:  ${ENGINE_REF}" \
+            -m "Built and pushed from aegis-core commit ${RUN_SHA}."
           # --force: re-run for the same source commit recreates the same
           # branch; the fresh bump replaces the previous attempt.
           git push --force origin "${BRANCH}"
@@ -538,9 +548,9 @@ jobs:
           if [ -z "${EXISTING_PR}" ]; then
             gh pr create --repo BinHsu/aegis-core-deploy \
               --base main --head "${BRANCH}" \
-              --title "ci(deploy): bump aegis-core image tags to ${SHORT_SHA}" \
-              --body "$(printf 'Bumps both image references in the staging manifests to the build produced from aegis-core commit \`%s\`.\n\n**Images**\n- Gateway: `aegis-core:staging-%s`\n- Engine:  `aegis-core:engine-staging-%s`\n\nFull SHA: `%s`\n\nAutomated by `release-staging-image.yml` in aegis-core (ADR-0036). Auto-merge is armed: the PR squash-merges once the required CodeRabbit check/review passes.' \
-                "${SHORT_SHA}" "${RUN_SHA}" "${RUN_SHA}" "${RUN_SHA}")"
+              --title "ci(deploy): pin aegis-core staging digests (${SHORT_SHA})" \
+              --body "$(printf 'Pins the staging overlay BY DIGEST to the build produced from aegis-core commit \`%s\` (ADR-10/14/17 — build once, promote by digest; gateway + engine move atomically).\n\n**Digests**\n- Gateway: `aegis-core@%s`\n- Engine:  `aegis-core@%s`\n- Seed:    `aegis-core@%s` (== engine, ADR-14)\n\nFull SHA: `%s`\n\nAutomated by `release-staging-image.yml` in aegis-core. Auto-merge is armed: the PR squash-merges once the required CodeRabbit check/review passes.' \
+                "${RUN_SHA}" "${GATEWAY_DIGEST}" "${ENGINE_DIGEST}" "${ENGINE_DIGEST}" "${RUN_SHA}")"
           fi
           gh pr merge --auto --squash \
             --repo BinHsu/aegis-core-deploy "${BRANCH}"

--- a/frontend_web/public/config.json
+++ b/frontend_web/public/config.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Runtime config (ADR-15). Built once, served next to the bundle, swapped at deploy. This committed default is LOCAL mode for a fresh clone. Delete this file to fall back to VITE_AEGIS_* env (.env.local). The deploy pipeline overwrites it with the per-environment values (deployMode=cloud + cognito.* + gatewayEndpoint).",
+  "deployMode": "local",
+  "gatewayEndpoint": null,
+  "cognito": null
+}

--- a/frontend_web/src/lib/auth.ts
+++ b/frontend_web/src/lib/auth.ts
@@ -1,52 +1,68 @@
 // frontend_web/src/lib/auth.ts
 //
-// Module-level auth state per ADR-0034 §D2, after the 4e-2 refactor to
-// `react-oidc-context`. Two responsibilities:
+// Module-level auth state per ADR-0034 §D2 (react-oidc-context). Two
+// responsibilities:
 //
-//   1. In Cloud mode, own the `oidc-client-ts` UserManager — the
-//      single source of truth that both module-level code
-//      (gateway-client token interceptor) AND the React tree
-//      (react-oidc-context's <AuthProvider userManager={...}>) share.
+//   1. In Cloud mode, own the `oidc-client-ts` UserManager — the single
+//      source of truth that both module-level code (gateway-client token
+//      interceptor) AND the React tree (react-oidc-context's
+//      <AuthProvider userManager={...}>) share.
 //
 //   2. Wire a synchronous token getter into the gateway-client
-//      interceptor via `setAuthTokenGetter`. The interceptor runs
-//      per-RPC and cannot await; we keep a cached User that's
-//      updated via UserManager events.
+//      interceptor via setAuthTokenGetter. The interceptor runs per-RPC
+//      and cannot await; we keep a cached User updated via UserManager
+//      events.
 //
-// In Local mode the UserManager is never constructed; the token
-// getter returns null so the gateway-client omits the Authorization
-// header (gateway-side NoOpProvider stamps a synthetic principal).
+// Lifecycle (ADR-15): the UserManager is built from RUNTIME config in
+// initAuth(cfg) — called once from main.tsx after loadConfig() — not at
+// module-load time. Pre-refactor this was a module-const that read
+// import.meta.env, which baked the Cognito settings into the bundle and
+// threw synchronously at import if they were missing.
+//
+// In Local mode the UserManager is never constructed; the token getter
+// is cleared so the gateway-client omits the Authorization header
+// (gateway-side NoOpProvider stamps a synthetic principal).
 
 import { type User, UserManager, WebStorageStateStore } from "oidc-client-ts";
 
+import { type AppConfig, type CognitoConfig } from "./config";
 import { setAuthTokenGetter } from "./gateway-client";
 
-const DEPLOY_MODE = (import.meta.env["VITE_AEGIS_DEPLOY_MODE"] ?? "local") as
-  | "local"
-  | "cloud";
+/** The singleton UserManager for Cloud mode. Null until initAuth runs
+ *  in Cloud mode; stays null in Local mode. */
+let cloudUserManager: UserManager | null = null;
 
 /**
- * The singleton UserManager for Cloud mode. Null in Local mode.
- *
- * Exported for <AuthProvider userManager={...}> in AegisAuthShell —
- * sharing the instance keeps module-level code (token getter below)
- * and React-level code (react-oidc-context's useAuth()) reading the
- * same session state.
+ * Accessor for the Cloud UserManager. Exported for
+ * <AuthProvider userManager={...}> in AegisAuthShell — sharing the
+ * instance keeps module-level code (token getter below) and React-level
+ * code (react-oidc-context's useAuth()) reading the same session state.
  */
-export const cloudUserManager: UserManager | null =
-  DEPLOY_MODE === "cloud" ? buildCloudUserManager() : null;
+export function getCloudUserManager(): UserManager | null {
+  return cloudUserManager;
+}
 
-/**
- * Latest authenticated user, refreshed from UserManager events. The
- * gateway-client interceptor reads through `getAccessToken()` below
- * which inspects this — keeping it in module scope avoids an async
- * `getUser()` per RPC.
- */
+/** Latest authenticated user, refreshed from UserManager events. The
+ *  gateway-client interceptor reads through the registered getter which
+ *  inspects this — module scope avoids an async getUser() per RPC. */
 let cachedUser: User | null = null;
 
-if (cloudUserManager) {
-  // Hydrate from any persisted session (user landed on the page with
-  // a valid Cognito session still in localStorage).
+/**
+ * Initialize auth from runtime config. Cloud mode builds the
+ * UserManager, hydrates any persisted session, and registers the token
+ * getter. Local mode clears the getter (no Authorization header). Call
+ * once from main.tsx after loadConfig().
+ */
+export function initAuth(cfg: AppConfig): void {
+  if (cfg.deployMode !== "cloud" || cfg.cognito === null) {
+    setAuthTokenGetter(null);
+    return;
+  }
+
+  cloudUserManager = buildCloudUserManager(cfg.cognito);
+
+  // Hydrate from any persisted session (user landed with a valid
+  // Cognito session still in localStorage).
   void cloudUserManager.getUser().then((u) => {
     cachedUser = u && !u.expired ? u : null;
   });
@@ -59,70 +75,48 @@ if (cloudUserManager) {
   cloudUserManager.events.addAccessTokenExpired(() => {
     cachedUser = null;
   });
+
+  setAuthTokenGetter(() => {
+    if (!cachedUser || cachedUser.expired) return null;
+    return cachedUser.access_token ?? null;
+  });
 }
 
-setAuthTokenGetter(() => {
-  if (!cachedUser || cachedUser.expired) return null;
-  return cachedUser.access_token ?? null;
-});
-
 /**
- * Process the OIDC redirect callback. Called from AuthCallbackPage
- * on the `/auth/callback` route. Cloud mode: exchanges the
- * ?code=&state= query params for tokens via the UserManager. Local
- * mode: no-op (the router still sends users here for URL uniformity,
- * but there's nothing to do).
+ * Process the OIDC redirect callback. Called from AuthCallbackPage on
+ * the `/auth/callback` route. Cloud mode: exchanges the ?code=&state=
+ * query params for tokens via the UserManager. Local mode (or before
+ * initAuth): no-op.
  *
- * Kept as an imperative helper rather than relying on
- * react-oidc-context's onSigninCallback prop because the callback
- * page needs to navigate to /host after completion — imperative
- * control makes the sequence (process → navigate) obvious at the
- * consumer.
+ * Kept imperative rather than relying on react-oidc-context's
+ * onSigninCallback prop because the callback page needs to navigate to
+ * /host after completion — imperative control makes the sequence
+ * (process → navigate) obvious at the consumer.
  */
 export async function handleSignInCallback(): Promise<void> {
   if (cloudUserManager === null) return;
   await cloudUserManager.signinRedirectCallback();
 }
 
-function buildCloudUserManager(): UserManager {
-  const env = import.meta.env;
-  const authority = env["VITE_AEGIS_COGNITO_AUTHORITY"];
-  const clientId = env["VITE_AEGIS_COGNITO_CLIENT_ID"];
-  const redirectUri = env["VITE_AEGIS_COGNITO_REDIRECT_URI"];
-  const logoutUriEnv = env["VITE_AEGIS_COGNITO_LOGOUT_URI"];
-  if (!authority || !clientId || !redirectUri) {
-    throw new Error(
-      "lib/auth: missing required Cognito env vars. Need " +
-        "VITE_AEGIS_COGNITO_AUTHORITY, VITE_AEGIS_COGNITO_CLIENT_ID, " +
-        "VITE_AEGIS_COGNITO_REDIRECT_URI. (Set in .env.local for dev or " +
-        "pass via the build step in CI.)",
-    );
-  }
-  // Empty-string unset protection — a .env with the var declared but
-  // blank (`VITE_AEGIS_COGNITO_LOGOUT_URI=`) should behave the same as
-  // omitting the line.
-  const logoutUri =
-    logoutUriEnv && logoutUriEnv !== "" ? logoutUriEnv : undefined;
-
+function buildCloudUserManager(cognito: CognitoConfig): UserManager {
+  const { authority, clientId, redirectUri, logoutUri } = cognito;
   return new UserManager({
     authority,
     client_id: clientId,
     redirect_uri: redirectUri,
     // Cognito's logout endpoint expects a `logout_uri` query param
     // matching one of the app client's logout_urls — oidc-client-ts
-    // populates this from post_logout_redirect_uri. LDZ's Terraform
-    // registers the strawman per aegis-core#76.
+    // populates this from post_logout_redirect_uri.
     ...(logoutUri ? { post_logout_redirect_uri: logoutUri } : {}),
     response_type: "code",
     scope: "openid profile email",
-    // WebStorageStateStore(localStorage) persists the User so a
-    // page reload during a meeting doesn't lose the session. ADR-0034
-    // §D2 originally called for memory-only storage to mitigate XSS,
-    // but Phase 3 SPA work landed localStorage with an explicit
-    // comment on the tradeoff; preserved here because the 4e-2
-    // refactor's goal is library swap, not security-policy change.
-    // When LDZ's Cognito pool goes live, revisit this choice in a
-    // dedicated ADR revision.
+    // WebStorageStateStore(localStorage) persists the User so a page
+    // reload during a meeting doesn't lose the session. ADR-0034 §D2
+    // originally called for memory-only storage to mitigate XSS; Phase 3
+    // landed localStorage with an explicit tradeoff comment. Preserved
+    // here — this refactor's goal is the config source, not the
+    // security-policy choice. Revisit in a dedicated ADR when the
+    // Cognito pool goes live.
     userStore: new WebStorageStateStore({ store: window.localStorage }),
     automaticSilentRenew: true,
   });

--- a/frontend_web/src/lib/config.ts
+++ b/frontend_web/src/lib/config.ts
@@ -1,0 +1,124 @@
+// frontend_web/src/lib/config.ts
+//
+// Runtime configuration (ADR-15). The SPA is built ONCE and configured
+// at deploy time by a `/config.json` served next to the bundle — the
+// SAME immutable bundle runs on-prem (Dex) and on AWS (Cognito) by
+// swapping config.json, instead of baking VITE_* into the build.
+//
+// Contract:
+//   - loadConfig() MUST be awaited in main.tsx BEFORE the app renders.
+//   - Every consumer reads through the synchronous getConfig() after.
+//   - A missing/partial /config.json falls back to import.meta.env, so
+//     `npm run dev` keeps working from a .env.local (or no config at
+//     all) — delete public/config.json to get the env-fallback path.
+
+export type DeployMode = "local" | "cloud";
+
+export interface CognitoConfig {
+  readonly authority: string;
+  readonly clientId: string;
+  readonly redirectUri: string;
+  readonly logoutUri?: string;
+}
+
+export interface AppConfig {
+  readonly deployMode: DeployMode;
+  /** Resolved gateway base URL (same-host:8080 default already applied). */
+  readonly gatewayEndpoint: string;
+  /** Cognito settings in Cloud mode; null in Local mode. */
+  readonly cognito: CognitoConfig | null;
+}
+
+interface RawConfig {
+  deployMode?: string;
+  gatewayEndpoint?: string | null;
+  cognito?: Partial<CognitoConfig> | null;
+}
+
+let cached: AppConfig | null = null;
+
+/**
+ * Same-host:8080 (NOT hard-coded localhost) so the LAN-viewer QR flow
+ * works: a phone loading the page from http://192.168.x.y:5173 computes
+ * http://192.168.x.y:8080 for the gateway. Matches the old per-page
+ * default that this module now centralizes.
+ */
+function defaultGatewayEndpoint(): string {
+  if (typeof window === "undefined") return "http://localhost:8080";
+  return `${window.location.protocol}//${window.location.hostname}:8080`;
+}
+
+function envStr(key: string): string | undefined {
+  const v = (import.meta.env as Record<string, unknown>)[key];
+  return typeof v === "string" && v !== "" ? v : undefined;
+}
+
+function normalize(raw: RawConfig): AppConfig {
+  const deployMode: DeployMode =
+    (raw.deployMode ?? envStr("VITE_AEGIS_DEPLOY_MODE") ?? "local") === "cloud"
+      ? "cloud"
+      : "local";
+
+  const gatewayEndpoint =
+    raw.gatewayEndpoint ??
+    undefined ??
+    envStr("VITE_AEGIS_GATEWAY_ENDPOINT") ??
+    defaultGatewayEndpoint();
+
+  let cognito: CognitoConfig | null = null;
+  if (deployMode === "cloud") {
+    const c = raw.cognito ?? {};
+    const authority = c.authority ?? envStr("VITE_AEGIS_COGNITO_AUTHORITY");
+    const clientId = c.clientId ?? envStr("VITE_AEGIS_COGNITO_CLIENT_ID");
+    const redirectUri =
+      c.redirectUri ?? envStr("VITE_AEGIS_COGNITO_REDIRECT_URI");
+    const logoutUri = c.logoutUri ?? envStr("VITE_AEGIS_COGNITO_LOGOUT_URI");
+    if (!authority || !clientId || !redirectUri) {
+      throw new Error(
+        "config: deployMode=cloud requires cognito.authority, cognito.clientId, " +
+          "and cognito.redirectUri (from /config.json or VITE_AEGIS_COGNITO_* env).",
+      );
+    }
+    cognito = {
+      authority,
+      clientId,
+      redirectUri,
+      ...(logoutUri ? { logoutUri } : {}),
+    };
+  }
+
+  return { deployMode, gatewayEndpoint, cognito };
+}
+
+/**
+ * Fetch /config.json at boot, normalize it (with env fallback), cache.
+ * Call once in main.tsx and await before render.
+ */
+export async function loadConfig(): Promise<AppConfig> {
+  let raw: RawConfig = {};
+  try {
+    const res = await fetch("/config.json", { cache: "no-store" });
+    if (res.ok) {
+      raw = (await res.json()) as RawConfig;
+    }
+  } catch {
+    // No served config.json (e.g. `npm run dev`) — fall through to the
+    // import.meta.env fallback inside normalize().
+  }
+  cached = normalize(raw);
+  return cached;
+}
+
+/**
+ * Synchronous accessor. Throws if called before loadConfig() resolves —
+ * a loud failure beats a silent half-configured app.
+ */
+export function getConfig(): AppConfig {
+  if (cached === null) {
+    throw new Error(
+      "config: getConfig() called before loadConfig(). loadConfig() must be " +
+        "awaited in main.tsx before the app renders.",
+    );
+  }
+  return cached;
+}

--- a/frontend_web/src/lib/consent.ts
+++ b/frontend_web/src/lib/consent.ts
@@ -10,6 +10,8 @@
 // The consent-record SHAPE is stable across the Phase 3 → Phase 4
 // migration so no caller code changes when the wire path moves.
 
+import { getConfig } from "./config";
+
 /**
  * Privacy-policy version. Bump when the copy in
  * `AudioProcessingConsent.tsx` materially changes; bumping invalidates
@@ -57,9 +59,7 @@ function clientMetadata(): {
   return {
     userAgent:
       typeof navigator !== "undefined" ? navigator.userAgent : "unknown",
-    deployMode:
-      (import.meta.env["VITE_AEGIS_DEPLOY_MODE"] as string | undefined) ??
-      "local",
+    deployMode: getConfig().deployMode,
   };
 }
 

--- a/frontend_web/src/lib/gateway-client.ts
+++ b/frontend_web/src/lib/gateway-client.ts
@@ -1,8 +1,8 @@
 // frontend_web/src/lib/gateway-client.ts
 //
 // Single thin wrapper around the generated Connect-ES `Gateway` service
-// client. Both the Host and Viewer pages should import the singleton
-// from here rather than constructing transports themselves — that way
+// client. Both the Host and Viewer pages reach the singleton through
+// `getGatewayClient()` rather than constructing transports themselves —
 // the `baseUrl`, the auth-header injector, and any future cross-cutting
 // concerns (request-id generation, retry policy, telemetry hooks) live
 // in one auditable spot.
@@ -11,93 +11,79 @@
 // `@connectrpc/connect-web` speaks the grpc-web wire protocol, which
 // matches the `improbable-eng/grpc-web` wrapper mounted on the Go
 // Gateway's HTTP :8080 listener (see `gateway_go/cmd/gateway/main.go`
-// — the IsGrpcWebRequest sniff branch). Same proto definitions across
-// the wire; just a client-side library choice.
+// — the IsGrpcWebRequest sniff branch).
 //
-// Auth posture: the transport accepts an optional `getAuthToken` thunk
-// that is called per-request. A nullable return means "send no
-// Authorization header" — the Local-mode default. The Cloud-mode
-// `CognitoAuthProvider` returns the current bearer token. The
-// asymmetric closure shape avoids forcing every call site to know
-// which deploy mode is active.
+// Lifecycle (ADR-15): the transport's baseUrl comes from runtime config,
+// so the client is BUILT in initGatewayClient(cfg) — called once from
+// main.tsx after loadConfig() — not at module-load time. Pre-refactor
+// this was a module-const resolved from import.meta.env; that baked the
+// endpoint into the bundle.
+//
+// Auth posture: the transport calls an optional `getAuthToken` thunk
+// per request. A nullable return means "send no Authorization header" —
+// the Local-mode default. The Cloud-mode auth layer registers a getter
+// via setAuthTokenGetter that returns the current bearer token.
 
 import { createPromiseClient, type PromiseClient } from "@connectrpc/connect";
 import { createGrpcWebTransport } from "@connectrpc/connect-web";
 
 import { Gateway } from "@/gen/proto/aegis/v1/aegis_connect.js";
 
-/**
- * Resolved at module-load time so the rest of the app holds a stable
- * reference. Production builds set `VITE_AEGIS_GATEWAY_ENDPOINT` via
- * env at `vite build` time.
- *
- * Dev-default falls back to the SAME HOST the frontend was served from
- * (not hard-coded `localhost`), port 8080. This matters for the
- * LAN-viewer demo flow: when the host-laptop user opens
- * `http://192.168.x.y:5173/host` and the QR code lands a phone on
- * `http://192.168.x.y:5173/view/...`, the phone's bundle computes
- * `http://192.168.x.y:8080` for the gateway — reachable because the
- * gateway binds on 0.0.0.0 (ADR-0007 LAN bind). Hard-coding
- * `localhost` would break the phone case silently (CORS-block or
- * ERR_CONNECTION_REFUSED).
- */
-function defaultGatewayBaseURL(): string {
-  if (typeof window === "undefined") {
-    return "http://localhost:8080";
-  }
-  return `${window.location.protocol}//${window.location.hostname}:8080`;
-}
-
-const GATEWAY_BASE_URL: string =
-  import.meta.env["VITE_AEGIS_GATEWAY_ENDPOINT"] ?? defaultGatewayBaseURL();
+import type { AppConfig } from "./config";
 
 /**
- * Per-request auth-header thunk. Mutable so the AuthProvider layer can
- * register a getter once at startup; the transport re-invokes it on
- * every RPC so a token refresh during a long-lived session is picked
- * up without re-creating the client.
+ * Per-request auth-header thunk. Mutable so the auth layer can register
+ * a getter once at startup; the transport re-invokes it on every RPC so
+ * a token refresh during a long-lived session is picked up without
+ * re-creating the client.
  */
 let authTokenGetter: (() => string | null) | null = null;
 
 /**
- * Register the function the transport will call to fetch the current
- * Authorization bearer token. Pass `null` (or omit) to revert to the
- * Local-mode "send no header" behavior.
- *
- * Idempotent: subsequent calls overwrite the prior getter. Typical
- * call site: the AuthProvider's "signed in" callback.
+ * Register the function the transport calls to fetch the current
+ * Authorization bearer token. Pass `null` to revert to the Local-mode
+ * "send no header" behavior. Idempotent.
  */
 export function setAuthTokenGetter(getter: (() => string | null) | null): void {
   authTokenGetter = getter;
 }
 
-/**
- * The Connect transport. Built once per page load. The
- * `interceptors` array is the Connect-idiomatic way to inject
- * cross-cutting per-request behavior — here we use it to layer the
- * Authorization header onto the request metadata before dispatch.
- */
-const transport = createGrpcWebTransport({
-  baseUrl: GATEWAY_BASE_URL,
-  interceptors: [
-    (next) => async (req) => {
-      const token = authTokenGetter?.() ?? null;
-      if (token !== null && token !== "") {
-        req.header.set("Authorization", `Bearer ${token}`);
-      }
-      return next(req);
-    },
-  ],
-});
+let client: PromiseClient<typeof Gateway> | null = null;
 
 /**
- * The singleton Gateway client. Re-exporting the
- * `PromiseClient<typeof Gateway>` shape so call sites can type their
- * own helper functions without re-importing the service descriptor.
+ * Build the singleton Gateway client from runtime config. Call once in
+ * main.tsx after loadConfig(). The interceptor reads `authTokenGetter`
+ * dynamically, so initAuth() may register its getter before OR after
+ * this runs.
  */
-export const gatewayClient: PromiseClient<typeof Gateway> = createPromiseClient(
-  Gateway,
-  transport,
-);
+export function initGatewayClient(cfg: AppConfig): void {
+  const transport = createGrpcWebTransport({
+    baseUrl: cfg.gatewayEndpoint,
+    interceptors: [
+      (next) => async (req) => {
+        const token = authTokenGetter?.() ?? null;
+        if (token !== null && token !== "") {
+          req.header.set("Authorization", `Bearer ${token}`);
+        }
+        return next(req);
+      },
+    ],
+  });
+  client = createPromiseClient(Gateway, transport);
+}
+
+/**
+ * The singleton Gateway client. Throws if accessed before
+ * initGatewayClient() — a loud failure beats a silent unconfigured RPC.
+ */
+export function getGatewayClient(): PromiseClient<typeof Gateway> {
+  if (client === null) {
+    throw new Error(
+      "gateway-client: getGatewayClient() before initGatewayClient(). " +
+        "Call initGatewayClient(cfg) in main.tsx after loadConfig().",
+    );
+  }
+  return client;
+}
 
 export { Gateway };

--- a/frontend_web/src/main.tsx
+++ b/frontend_web/src/main.tsx
@@ -2,17 +2,22 @@
 //
 // Entry point. React root + router. Per ADR-0002 Constraint 2, nothing
 // here may call a browser API directly — all platform-specific paths
-// (audio capture, transport, storage) go through provider interfaces
-// in src/providers/ so Phase 4+ Tauri wrap can swap implementations.
+// (audio capture, transport, storage) go through provider interfaces in
+// src/providers/ so a Phase 4+ Tauri wrap can swap implementations.
+//
+// Boot order (ADR-15): fetch runtime config FIRST, then initialize the
+// gateway client and auth from it, THEN render. Config-dependent modules
+// (lib/gateway-client, lib/auth) no longer do work at import time — they
+// expose init*() functions called here, so the async config fetch
+// completes before anything reads it.
 
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
-// Load the auth singleton early — its module-side-effect constructs
-// the Cognito UserManager (Cloud mode) and wires the gateway-client
-// token interceptor before any RPC runs.
-import "./lib/auth";
+import { loadConfig } from "./lib/config";
+import { initGatewayClient } from "./lib/gateway-client";
+import { initAuth } from "./lib/auth";
 
 import { App } from "./App";
 import { AuthCallbackPage } from "./pages/AuthCallback/AuthCallbackPage";
@@ -31,24 +36,31 @@ const router = createBrowserRouter([
       //   /view/<session_id>?token=<jwt>
       // per ADR-0001.
       { path: "view/:sessionId", element: <ViewerPage /> },
-      // OIDC redirect target for the Cloud-mode Cognito Hosted UI
-      // flow. Local mode reaches this path too (LocalAuthProvider's
-      // handleSignInCallback is a no-op) so the router config stays
-      // mode-agnostic.
+      // OIDC redirect target for the Cloud-mode Cognito Hosted UI flow.
+      // Local mode reaches this path too (handleSignInCallback is a
+      // no-op) so the router config stays mode-agnostic.
       { path: "auth/callback", element: <AuthCallbackPage /> },
     ],
   },
 ]);
 
-const rootElement = document.getElementById("root");
-if (!rootElement) {
-  throw new Error("frontend_web: #root element missing from index.html");
+async function bootstrap(): Promise<void> {
+  const cfg = await loadConfig();
+  initGatewayClient(cfg);
+  initAuth(cfg);
+
+  const rootElement = document.getElementById("root");
+  if (!rootElement) {
+    throw new Error("frontend_web: #root element missing from index.html");
+  }
+
+  createRoot(rootElement).render(
+    <StrictMode>
+      <AegisAuthShell>
+        <RouterProvider router={router} />
+      </AegisAuthShell>
+    </StrictMode>,
+  );
 }
 
-createRoot(rootElement).render(
-  <StrictMode>
-    <AegisAuthShell>
-      <RouterProvider router={router} />
-    </AegisAuthShell>
-  </StrictMode>,
-);
+void bootstrap();

--- a/frontend_web/src/pages/Host/HostPage.tsx
+++ b/frontend_web/src/pages/Host/HostPage.tsx
@@ -52,7 +52,8 @@ import {
   TranscriptExportConsentModal,
   type TranscriptExportFormat,
 } from "@/components/TranscriptExportConsentModal";
-import { gatewayClient } from "@/lib/gateway-client";
+import { getConfig } from "@/lib/config";
+import { getGatewayClient } from "@/lib/gateway-client";
 import {
   formatTranscriptJson,
   formatTranscriptMarkdown,
@@ -148,12 +149,6 @@ const CURATED_SPEAKER_LABELS: readonly string[] = [
   "Speaker_3",
   "Unknown",
 ] as const;
-
-const DEPLOY_MODE = (import.meta.env["VITE_AEGIS_DEPLOY_MODE"] ?? "local") as
-  | "cloud"
-  | "local";
-const ENDPOINT =
-  import.meta.env["VITE_AEGIS_GATEWAY_ENDPOINT"] ?? "http://localhost:8080";
 
 /**
  * The runtime data attached to an in-flight meeting. Mutable handles
@@ -481,7 +476,7 @@ export function HostPage(): JSX.Element {
     let cancelled = false;
     (async (): Promise<void> => {
       try {
-        const resp = await gatewayClient.listCorpora({ tenantId: "" });
+        const resp = await getGatewayClient().listCorpora({ tenantId: "" });
         if (cancelled) return;
         // Always prepend the opt-out entry so "No corpus" is present
         // even when the engine returns zero seeded corpora.
@@ -520,7 +515,7 @@ export function HostPage(): JSX.Element {
     let cancelled = false;
     void (async () => {
       try {
-        const res = await fetch(`${ENDPOINT}/lan-ip`);
+        const res = await fetch(`${getConfig().gatewayEndpoint}/lan-ip`);
         if (!res.ok) throw new Error(`/lan-ip returned ${res.status}`);
         const json = (await res.json()) as { best?: string };
         if (!cancelled) {
@@ -559,7 +554,7 @@ export function HostPage(): JSX.Element {
         }
 
         // 2. CreateMeeting RPC.
-        const createResp = await gatewayClient.createMeeting({
+        const createResp = await getGatewayClient().createMeeting({
           ragId,
           title,
           languageHints: [],
@@ -584,7 +579,7 @@ export function HostPage(): JSX.Element {
           throw new Error("peer.localDescription unexpectedly null");
         }
 
-        const negResp = await gatewayClient.negotiateWebRTC({
+        const negResp = await getGatewayClient().negotiateWebRTC({
           sessionId: createResp.sessionId,
           offerSdp: peer.localDescription.sdp,
         });
@@ -597,8 +592,8 @@ export function HostPage(): JSX.Element {
         //    viewer. The host watching their own session catches
         //    "engine isn't transcribing" instantly.
         const streamProvider = pickTranscriptStreamProvider({
-          deployMode: DEPLOY_MODE,
-          endpoint: ENDPOINT,
+          deployMode: getConfig().deployMode,
+          endpoint: getConfig().gatewayEndpoint,
         });
         subscription = streamProvider.subscribe(
           {
@@ -740,7 +735,7 @@ export function HostPage(): JSX.Element {
       console.warn("[host] capture.stop:", err);
     }
     try {
-      await gatewayClient.endMeeting({ sessionId: active.sessionId });
+      await getGatewayClient().endMeeting({ sessionId: active.sessionId });
     } catch (err) {
       console.warn("[host] EndMeeting RPC:", err);
     }
@@ -770,7 +765,8 @@ export function HostPage(): JSX.Element {
             void signIn();
           }}
         >
-          Sign in {DEPLOY_MODE === "cloud" ? "with Cognito" : "(local)"}
+          Sign in{" "}
+          {getConfig().deployMode === "cloud" ? "with Cognito" : "(local)"}
         </button>
       </main>
     );
@@ -1361,7 +1357,7 @@ function HintPanel({
 }
 
 /**
- * Staff-authored hint input. Calls `gatewayClient.sendOfficerHint`;
+ * Staff-authored hint input. Calls `getGatewayClient().sendOfficerHint`;
  * the gateway broadcasts via `Session.Broadcast` and the fan-out
  * echoes back onto the host's own subscription, which lands in the
  * HintPanel below — that's how the staff confirms the hint went out.
@@ -1393,7 +1389,7 @@ function StaffHintInputPanel({
       setSending(true);
       setSendError(null);
       try {
-        await gatewayClient.sendOfficerHint({
+        await getGatewayClient().sendOfficerHint({
           sessionId,
           viewerToken,
           suggestion: trimmed,

--- a/frontend_web/src/pages/Viewer/ViewerPage.tsx
+++ b/frontend_web/src/pages/Viewer/ViewerPage.tsx
@@ -22,23 +22,14 @@ import {
   useSentenceStitcher,
   type StitchedLine,
 } from "@/hooks/useSentenceStitcher";
+import { getConfig } from "@/lib/config";
 
 const PROMPTER_WINDOW = 5;
 
-// Deploy mode + endpoint are normally injected at build time via Vite
-// env vars. The default for ENDPOINT falls back to same-host:8080
-// (not hardcoded `localhost`) so the LAN-scan-QR-code viewer flow
-// works out of the box — a phone loading this page from
-// `http://192.168.x.y:5173/view/...` automatically points at
-// `http://192.168.x.y:8080` for the gateway.
-const DEPLOY_MODE = (import.meta.env["VITE_AEGIS_DEPLOY_MODE"] ?? "local") as
-  | "cloud"
-  | "local";
-const ENDPOINT =
-  import.meta.env["VITE_AEGIS_GATEWAY_ENDPOINT"] ??
-  (typeof window !== "undefined"
-    ? `${window.location.protocol}//${window.location.hostname}:8080`
-    : "http://localhost:8080");
+// Deploy mode + endpoint come from runtime config (ADR-15). gatewayEndpoint
+// resolves to same-host:8080 by default (not hardcoded `localhost`) so the
+// LAN-scan-QR-code viewer flow works — a phone loading this page from
+// `http://192.168.x.y:5173/view/...` points at `http://192.168.x.y:8080`.
 
 export function ViewerPage(): JSX.Element {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -63,8 +54,8 @@ export function ViewerPage(): JSX.Element {
   const provider = useMemo(
     () =>
       pickTranscriptStreamProvider({
-        deployMode: DEPLOY_MODE,
-        endpoint: ENDPOINT,
+        deployMode: getConfig().deployMode,
+        endpoint: getConfig().gatewayEndpoint,
       }),
     [],
   );
@@ -153,8 +144,9 @@ export function ViewerPage(): JSX.Element {
     <main>
       <h2>Viewer</h2>
       <p style={{ color: "#888", fontSize: "0.85rem" }}>
-        Session <code>{sessionId}</code> — transport <code>{DEPLOY_MODE}</code>{" "}
-        via <code>{ENDPOINT}</code>
+        Session <code>{sessionId}</code> — transport{" "}
+        <code>{getConfig().deployMode}</code> via{" "}
+        <code>{getConfig().gatewayEndpoint}</code>
       </p>
 
       {state === "host-reconnecting" && (

--- a/frontend_web/src/providers/AuthProvider/AegisAuthShell.tsx
+++ b/frontend_web/src/providers/AuthProvider/AegisAuthShell.tsx
@@ -35,13 +35,10 @@ import {
   useMemo,
 } from "react";
 
-import { cloudUserManager } from "@/lib/auth";
+import { getCloudUserManager } from "@/lib/auth";
+import { getConfig } from "@/lib/config";
 
 import type { AuthPrincipal } from "./types";
-
-const DEPLOY_MODE = (import.meta.env["VITE_AEGIS_DEPLOY_MODE"] ?? "local") as
-  | "local"
-  | "cloud";
 
 const TENANT_CLAIM = "custom:tenant_id";
 
@@ -99,15 +96,16 @@ export function AegisAuthShell({
 }: {
   readonly children: ReactNode;
 }): ReactElement {
-  if (DEPLOY_MODE === "cloud") {
+  if (getConfig().deployMode === "cloud") {
+    const cloudUserManager = getCloudUserManager();
     if (cloudUserManager === null) {
-      // Defensive: `lib/auth.ts` constructs the UserManager when
-      // DEPLOY_MODE is "cloud", so reaching here means the env-var
-      // wiring is inconsistent (e.g. vite bundled one value, runtime
-      // got another). Fail loudly rather than render a half-mode UI.
+      // Defensive: initAuth() constructs the UserManager when
+      // deployMode is "cloud", so reaching here means the config
+      // wiring is inconsistent (cloud mode but no Cognito settings).
+      // Fail loudly rather than render a half-mode UI.
       throw new Error(
-        "AegisAuthShell: DEPLOY_MODE=cloud but cloudUserManager is null. " +
-          "Check VITE_AEGIS_DEPLOY_MODE and VITE_AEGIS_COGNITO_* env vars.",
+        "AegisAuthShell: deployMode=cloud but cloudUserManager is null. " +
+          "Check /config.json (deployMode + cognito.*) or VITE_AEGIS_COGNITO_* env.",
       );
     }
     return (

--- a/frontend_web/src/providers/TranscriptStreamProvider/WebSocketTranscriptStreamProvider.test.ts
+++ b/frontend_web/src/providers/TranscriptStreamProvider/WebSocketTranscriptStreamProvider.test.ts
@@ -116,7 +116,11 @@ function encodeViewerEvent(build: (ve: ProtoViewerEvent) => void): ArrayBuffer {
   // underlying buffer is exactly the right size (toBinary() returns
   // a Uint8Array that can share a larger backing buffer via pool
   // allocators).
-  return bytes.buffer.slice(
+  // TS 5.7's lib types Uint8Array.buffer as ArrayBuffer | SharedArrayBuffer;
+  // a WebSocket "arraybuffer" frame is always a plain ArrayBuffer. Assert it
+  // so .slice() returns ArrayBuffer (pre-existing, unrelated to the config
+  // refactor — surfaced by a fresh dependency install with no lockfile).
+  return (bytes.buffer as ArrayBuffer).slice(
     bytes.byteOffset,
     bytes.byteOffset + bytes.byteLength,
   );


### PR DESCRIPTION
WS3 non-AWS prep (no AWS apply; PR CI is validate/build only).

**A1 (ADR-15) — frontend runtime config.** SPA reads `/config.json` at boot instead of baked `VITE_*`, so one immutable bundle runs on-prem (Dex) and AWS (Cognito) by swapping config. New `src/lib/config.ts`; `UserManager` + gateway baseURL deferred to async init in `main.tsx`; consumers read `getConfig()`; `release-staging-frontend.yml` writes the per-env `config.json` to S3 (short cache, excluded from the immutable sync).

**A5 (ADR-14/17) — CI digest commit-back.** `release-staging-image.yml` pins the deploy overlay BY DIGEST (gateway + engine + seed, one atomic commit) instead of mutable tags; the push job exposes the captured digests as job outputs.

Also fixes a pre-existing TS 5.7.2 type error in a WebSocket test (`tsc -b` could not build before).

**Verified** (pnpm 8.6.7 frozen lockfile, TS 5.7.2): build + 40 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added runtime configuration support, enabling deployment-time customization of gateway endpoints and authentication settings without rebuilding the application.

* **Chores**
  * Updated deployment workflows to improve image manifest handling, caching strategies, and initialization sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->