### PR TITLE
fix(ws3): push aegis-core images to the deployment-account ECR

### DIFF
--- a/.github/workflows/release-staging-image.yml
+++ b/.github/workflows/release-staging-image.yml
@@ -61,7 +61,16 @@ env:
   # (per ADR-0027 §"GH Variables over hardcode/Secrets"). Forker
   # overrides at Settings → Variables; no YAML edit needed.
   AWS_REGION: ${{ vars.AWS_REGION }}
-  ECR_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/${{ vars.ECR_PUSH_ROLE_NAME }}
+  # aegis-core images live in the SHARED deployment-account ECR (ADR-10 ph2), not
+  # a per-account repo. ECR_PUSH_ROLE_ARN is the deployment-account role
+  # (aegis-core-ci-push) this workflow assumes cross-account to push; staging and
+  # prod then pull from that single registry. Previously this assembled a
+  # per-account ARN from AWS_ACCOUNT_ID, so the push landed in the staging
+  # account while the workloads pulled from the deployment account — empty repo,
+  # gateway ImagePullBackOff (2026-06-18). The per-account repo + push role have
+  # been removed (aegis-platform envs/platform/ecr.tf + envs/bootstrap), so a
+  # regression now fails loud at push time.
+  ECR_ROLE_ARN: ${{ vars.ECR_PUSH_ROLE_ARN }}
   ECR_REPOSITORY: ${{ vars.ECR_REPO_NAME }}
 
 jobs:


### PR DESCRIPTION
## Root cause (caught live 2026-06-18)
Gateway `ImagePullBackOff`: the deployment-account ECR `aegis-core` was empty, but the image existed — in the **staging** account. This workflow built `ECR_ROLE_ARN` from `vars.AWS_ACCOUNT_ID` (staging) + `vars.ECR_PUSH_ROLE_NAME`, so it assumed a staging role and pushed to the per-account repo, while the deploy (`REGISTRIES_JSON.ecr_account_id = 162975888022`) pulls from the deployment account.

## What
`ECR_ROLE_ARN` now comes from a single repo variable **`ECR_PUSH_ROLE_ARN`** = `arn:aws:iam::162975888022:role/aegis-core-ci-push` (the deployment-account push role the platform already provisions; its trust already allows `repo:BinHsu/aegis-core:ref:refs/heads/main`). `amazon-ecr-login` then resolves the deployment registry, and `ECR_REPOSITORY` (`aegis-core`) is the repo there. Staging+prod pull cross-account (`shared_core_pull`, already granted).

## Pairs with
aegis-platform **#98** — removes the per-account `aegis-core` repo + Role E. **Merge THIS first, then verify a publish lands in `162975888022/aegis-core`, then merge #98** (so we never have "nowhere to push").

## Verification
Workflow YAML valid. The `ECR_PUSH_ROLE_ARN` variable is set. (A live publish run will confirm the cross-account assume + push.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to streamline AWS credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->