### PR TITLE
ci(scorecard): prettier-format the workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,7 +3,7 @@ name: Scorecard supply-chain security
 on:
   branch_protection_rule:
   schedule:
-    - cron: "30 1 * * 1"   # weekly Monday 01:30 UTC
+    - cron: "30 1 * * 1" # weekly Monday 01:30 UTC
   push:
     branches: [main]
 


### PR DESCRIPTION
Fixes the CI Baseline pre-commit (prettier) failure on main: the scorecard SHA-fix heredoc was not prettier-formatted. Whitespace-only reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)