### PR TITLE
fix(ci): registry-authoritative digest via ecr describe-images (#141)

### DIFF
--- a/.github/workflows/release-staging-image.yml
+++ b/.github/workflows/release-staging-image.yml
@@ -204,13 +204,34 @@ jobs:
           TAG="staging-${GITHUB_SHA}"
           REPO="${ECR_REGISTRY}/${ECR_REPOSITORY}"
           echo "Pushing ${REPO}:${TAG}"
-          # Capture push output so we can extract the manifest digest
-          # for the downstream Cosign sign + attest steps. oci_push
-          # prints the digest as `<repo>@sha256:...` on its last lines.
           ./tools/bazelisk/bazelisk run //packaging/gateway:push_staging -- \
             --repository "${REPO}" \
-            --tag "${TAG}" 2>&1 | tee /tmp/gateway-push.log
-          DIGEST=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/gateway-push.log | tail -1)
+            --tag "${TAG}"
+
+          # REGISTRY-AUTHORITATIVE digest resolution (fix #141).
+          # `aws ecr describe-images` by the immutable just-pushed tag is
+          # the only ground truth for what is pullable. Greeter publish.yml
+          # :134-138 proved this pattern necessary after buildx/oci_push log
+          # grep reported a digest that did not exist in the registry →
+          # ErrImagePull NotFound in downstream pods.
+          DIGEST="$(aws ecr describe-images \
+            --region "${AWS_REGION}" \
+            --repository-name "${ECR_REPOSITORY}" \
+            --image-ids imageTag="${TAG}" \
+            --query 'imageDetails[0].imageDigest' --output text)"
+
+          # Sanity check: fail loudly on empty or malformed digest so a
+          # silent empty value never flows into Cosign sign/attest or the
+          # deploy-repo digest pin.
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::ecr describe-images returned empty digest for ${ECR_REPOSITORY}:${TAG} — aborting"
+            exit 1
+          fi
+          case "${DIGEST}" in
+            sha256:[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]) ;;
+            *) echo "::error::resolved gateway digest is not sha256:<64 hex>: '${DIGEST}'"; exit 1 ;;
+          esac
+
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "ref=${REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "::notice title=Gateway image pushed::${REPO}:${TAG} (${DIGEST})"
@@ -273,8 +294,29 @@ jobs:
           echo "Pushing ${REPO}:${TAG}"
           ./tools/bazelisk/bazelisk run //packaging/engine:push_staging -- \
             --repository "${REPO}" \
-            --tag "${TAG}" 2>&1 | tee /tmp/engine-push.log
-          DIGEST=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/engine-push.log | tail -1)
+            --tag "${TAG}"
+
+          # REGISTRY-AUTHORITATIVE digest resolution (fix #141).
+          # Same pattern as the gateway step above — see that comment for
+          # the full rationale. The same ECR repo holds both images
+          # (distinguished by tag prefix); `imageTag` selects this push
+          # unambiguously.
+          DIGEST="$(aws ecr describe-images \
+            --region "${AWS_REGION}" \
+            --repository-name "${ECR_REPOSITORY}" \
+            --image-ids imageTag="${TAG}" \
+            --query 'imageDetails[0].imageDigest' --output text)"
+
+          # Sanity check: fail loudly on empty or malformed digest.
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::ecr describe-images returned empty digest for ${ECR_REPOSITORY}:${TAG} — aborting"
+            exit 1
+          fi
+          case "${DIGEST}" in
+            sha256:[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]) ;;
+            *) echo "::error::resolved engine digest is not sha256:<64 hex>: '${DIGEST}'"; exit 1 ;;
+          esac
+
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "ref=${REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "::notice title=Engine image pushed::${REPO}:${TAG} (${DIGEST})"


### PR DESCRIPTION
## Root cause

`release-staging-image.yml` extracted the push digest by grepping Bazel `oci_push` stdout:

```bash
DIGEST=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/{gateway,engine}-push.log | tail -1)
```

`oci_push` can emit a buildx provenance/index digest in its log that does not exist as a pullable manifest in ECR. That wrong digest flows silently into:
- Cosign `sign` / `attest` steps (signs a non-existent manifest)
- `aegis-core-deploy` staging overlay digest pin (pods crash-loop: `ErrImagePull NotFound`)

This is the same class of failure fixed in aegis-greeter `publish.yml`:134-138.

## Fix

After each push, resolve the digest by querying the registry directly:

```bash
DIGEST="$(aws ecr describe-images \
  --region "${AWS_REGION}" \
  --repository-name "${ECR_REPOSITORY}" \
  --image-ids imageTag="${TAG}" \
  --query 'imageDetails[0].imageDigest' --output text)"
```

The just-pushed tag is immutable in ECR, so `describe-images` is the only authoritative source. OIDC credentials are already configured before the push step (no auth change needed). The shared `ECR_REPOSITORY` var is correct for both images — consistent with the existing cross-region replication wait step that already calls `describe-images` on the same repo.

**Source pattern:** `aegis-greeter` `publish.yml`:134-138 — proved necessary after a `sha256:46c383…` buildx manifest did not exist in the registry while the tag pointed at `sha256:0e6f3e…`.

## Sanity checks added

Both gateway and engine steps now fail loudly (`exit 1` + `::error`) if the resolved digest is empty or does not match `sha256:<64 hex>`. No silent empty value can flow downstream.

## Scope

- Lines changed: two `run:` blocks in `push-staging-image` job (~7 lines removed, ~49 added)
- All downstream consumers of `$DIGEST` (`digest=` / `ref=` outputs, `::notice`, Cosign sign/attest, SLSA provenance, `bump-image-tag` digest pin) are unchanged
- No permission, trigger, or job structure changes

Closes #141. De-risks prod image promotion by ensuring the pinned digest is always pullable.

## Test plan

- [ ] Merge to `main` and observe `push-staging-image` job: confirm `aws ecr describe-images` returns a `sha256:` value and the `::notice` lines show it
- [ ] Confirm `aegis-core-deploy` staging PR receives a valid digest (not empty / wrong hash)
- [ ] (Negative) Manually set `imageTag` to a non-existent tag in a test run to confirm the sanity check exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBsAfKpGhq8iuXSBhWWNef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced reliability of staging image verification in the release workflow by implementing direct ECR validation with format checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->