### PR TITLE
fix(gateway): ship a real linux/arm64 gateway binary on the on-prem GHCR path

### DIFF
--- a/.github/workflows/release-onprem-image.yml
+++ b/.github/workflows/release-onprem-image.yml
@@ -120,9 +120,16 @@ jobs:
           echo "ref=${GHCR_ENGINE}@${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "::notice title=Engine image pushed::${GHCR_ENGINE}:${TAG} (${DIGEST})"
 
+      # arm64 gateway target (:image_arm64 / :push_onprem), NOT the amd64
+      # :image / :push_staging the ECR workflow uses. The gateway is pure Go
+      # and would cross-compile either arch, but :image packs the amd64
+      # cross-binary on an amd64 base — publishing THAT under the arm64 GHCR
+      # name shipped an amd64 ELF that `exec format error`d on the arm64
+      # Talos / Graviton nodes. :image_arm64 packs the linux/arm64 binary on
+      # the arm64 distroless base (see packaging/gateway/BUILD.bazel).
       - name: Build gateway OCI image (linux/arm64)
         if: ${{ inputs.push_gateway }}
-        run: ./tools/bazelisk/bazelisk build //packaging/gateway:image
+        run: ./tools/bazelisk/bazelisk build //packaging/gateway:image_arm64
 
       - name: Push gateway image to GHCR
         id: push-gateway
@@ -130,7 +137,7 @@ jobs:
         run: |
           set -euxo pipefail
           TAG="onprem-${GITHUB_SHA}"
-          ./tools/bazelisk/bazelisk run //packaging/gateway:push_staging -- \
+          ./tools/bazelisk/bazelisk run //packaging/gateway:push_onprem -- \
             --repository "${GHCR_GATEWAY}" \
             --tag "${TAG}" 2>&1 | tee /tmp/gateway-push.log
           DIGEST=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/gateway-push.log | tail -1)

--- a/gateway_go/cmd/gateway/BUILD.bazel
+++ b/gateway_go/cmd/gateway/BUILD.bazel
@@ -55,12 +55,24 @@ go_binary(
 # a Linux artifact regardless of the host running `bazel build`. Devs
 # can also `bazel build :gateway_linux_amd64` directly to inspect "what
 # does my code look like as a Linux ELF" without needing Docker.
-#
-# When Slice 3 (multi-arch image_index) lands, sibling targets
-# :gateway_linux_arm64 etc. get added here; YAGNI for Slice 1.
 go_cross_binary(
     name = "gateway_linux_amd64",
     platform = "@rules_go//go/toolchain:linux_amd64",
+    target = ":gateway",
+    visibility = ["//visibility:public"],
+)
+
+# Explicit linux/arm64 cross-compile target — the on-prem / Graviton path.
+# The local Talos cluster (apple/container) and Graviton EKS nodepools run
+# linux/arm64; //packaging/gateway:image_arm64 consumes this so the GHCR
+# image published by release-onprem-image.yml carries a real arm64 ELF
+# instead of an amd64 binary that `exec format error`s on arm64 nodes.
+# Mirrors :gateway_linux_amd64 — same pure-Go `:gateway`, different target
+# platform. (The engine cross-compiles natively via local_config_cc on the
+# arm64 runner, so it needs no equivalent here.)
+go_cross_binary(
+    name = "gateway_linux_arm64",
+    platform = "@rules_go//go/toolchain:linux_arm64",
     target = ":gateway",
     visibility = ["//visibility:public"],
 )

--- a/packaging/gateway/BUILD.bazel
+++ b/packaging/gateway/BUILD.bazel
@@ -3,15 +3,28 @@
 # Strategy in ADR-0025; per-attribute rationale inline below.
 #
 # Targets:
-#   //packaging/gateway:image         — OCI image directory (CI smoke target;
-#                                       no docker daemon needed to build)
-#   //packaging/gateway:image_load    — wraps :image for `docker load`
-#                                       (`bazel run` invokes the loader)
+#   //packaging/gateway:image          — amd64 OCI image directory (ECR/staging
+#                                        path; CI smoke target, no docker daemon
+#                                        needed to build)
+#   //packaging/gateway:image_load     — wraps :image for `docker load`
+#                                        (`bazel run` invokes the loader)
+#   //packaging/gateway:push_staging   — amd64 push (ECR via release-staging-image.yml)
+#   //packaging/gateway:image_arm64    — arm64 OCI image directory (on-prem /
+#                                        Graviton path: GHCR + local Talos)
+#   //packaging/gateway:image_arm64_load
+#                                      — wraps :image_arm64 for `docker load`
+#   //packaging/gateway:push_onprem    — arm64 push (GHCR via release-onprem-image.yml)
+#
+# Two arch variants, not a multi-arch image_index: the staging/ECR path is
+# amd64 (ubuntu-latest builders) and the on-prem/GHCR path is arm64
+# (ubuntu-24.04-arm builders feeding apple/container + Graviton). Each
+# workflow builds the single variant it needs; an image_index that fuses
+# both is deferred (Slice 3) — YAGNI while the two consumers are arch-pinned.
 #
 # NOT in this slice (deferred):
 #   - SBOM generation (Slice 2, Syft + CycloneDX)
-#   - ECR push (Slice 3, GitHub Actions OIDC role)
 #   - Cosign / SLSA L3 (Phase 4b)
+#   - multi-arch image_index fusing amd64 + arm64 (Slice 3)
 
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
@@ -27,8 +40,8 @@ load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 #     fragile across rules_pkg versions.
 # The image entrypoint is /usr/local/bin/gateway (clean Unix
 # convention); the underlying cross-binary's filename
-# `gateway_linux_amd64` is an artefact of the go_cross_binary rule
-# name and is hidden from the runtime via this rename.
+# (`gateway_linux_amd64` / `gateway_linux_arm64`) is an artefact of the
+# go_cross_binary rule name and is hidden from the runtime via this rename.
 pkg_files(
     name = "gateway_files",
     srcs = ["//gateway_go/cmd/gateway:gateway_linux_amd64"],
@@ -42,6 +55,25 @@ pkg_files(
 pkg_tar(
     name = "gateway_layer",
     srcs = [":gateway_files"],
+)
+
+# arm64 sibling of gateway_files/gateway_layer — packs the linux/arm64
+# cross-binary at the same /usr/local/bin/gateway path. Kept as a parallel
+# pair (not parameterised) so the amd64 layer above stays byte-for-byte
+# identical for the unchanged ECR path.
+pkg_files(
+    name = "gateway_files_arm64",
+    srcs = ["//gateway_go/cmd/gateway:gateway_linux_arm64"],
+    attributes = pkg_attributes(mode = "0755"),
+    prefix = "/usr/local/bin",
+    renames = {
+        "//gateway_go/cmd/gateway:gateway_linux_arm64": "gateway",
+    },
+)
+
+pkg_tar(
+    name = "gateway_layer_arm64",
+    srcs = [":gateway_files_arm64"],
 )
 
 # Compose the image:
@@ -81,6 +113,46 @@ oci_load(
     name = "image_load",
     image = ":image",
     repo_tags = ["aegis-core-gateway:dev-local"],
+)
+
+# arm64 image — the on-prem / Graviton variant consumed by
+# release-onprem-image.yml (GHCR). Identical composition to :image but
+# packs the arm64 layer and pins the arm64 distroless base EXPLICITLY.
+#
+# Why an explicit arm64 base instead of `@distroless_static`:
+#   `@distroless_static` is a multi-platform repo that resolves to the
+#   target-platform variant via a platform transition. On the single-arch
+#   arm64 on-prem runner that resolves correctly, but naming the arm64
+#   image directly (`@distroless_static_linux_arm64_v8`, already fetched in
+#   MODULE.bazel) removes any ambiguity on a multi-arch runner and makes
+#   the arm64 intent self-documenting at the build target. The previous
+#   bug was the on-prem workflow building :image (amd64 binary) and
+#   publishing it under the arm64 GHCR name — explicitness here is the fix.
+oci_image(
+    name = "image_arm64",
+    base = "@distroless_static_linux_arm64_v8",
+    entrypoint = ["/usr/local/bin/gateway"],
+    exposed_ports = [
+        "8080/tcp",
+        "9090/tcp",
+    ],
+    labels = {
+        "org.opencontainers.image.source": "https://github.com/BinHsu/aegis-core",
+        "org.opencontainers.image.title": "aegis-core-gateway",
+        "org.opencontainers.image.description": "Aegis Gateway — gRPC + gRPC-Web + WebRTC entry point.",
+        "org.opencontainers.image.licenses": "Apache-2.0",
+    },
+    tars = [":gateway_layer_arm64"],
+    user = "nonroot",
+    visibility = ["//visibility:public"],
+)
+
+# Local smoke for the arm64 image (only loads cleanly on an arm64 docker
+# daemon — e.g. Apple Silicon). Mirrors :image_load.
+oci_load(
+    name = "image_arm64_load",
+    image = ":image_arm64",
+    repo_tags = ["aegis-core-gateway:dev-local-arm64"],
 )
 
 # ECR push target — Phase 4a Slice 3.
@@ -124,6 +196,22 @@ oci_push(
     name = "push_staging",
     image = ":image",
     repository = "251774439261.dkr.ecr.eu-central-1.amazonaws.com/aegis-core",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+)
+
+# GHCR push for the arm64 on-prem image. Sibling of :push_staging, pushing
+# :image_arm64 instead of :image. release-onprem-image.yml ALWAYS passes
+# `--repository ghcr.io/binhsu/aegis-core-gateway` + `--tag onprem-<sha>`
+# at runtime; the BUILD-time `repository` below is rules_oci's required
+# default (analysis fails on an empty value) and is the upstream operator's
+# local-convenience GHCR target — never the secret-bearing value. Same
+# `target_compatible_with = linux` push-from-CI-only discipline as
+# :push_staging.
+oci_push(
+    name = "push_onprem",
+    image = ":image_arm64",
+    repository = "ghcr.io/binhsu/aegis-core-gateway",
     target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## Bug
The on-prem GHCR gateway image (`release-onprem-image.yml`, arm64 runner) built `//packaging/gateway:image`, which packs the **amd64** `gateway_linux_amd64` cross-binary on an arm64 base. The image was *labelled* arm64 but the **binary was amd64** → `exec format error` on real arm64 nodes (AWS Graviton t4g). The engine escaped this (it compiles natively via `local_config_cc`). On-prem (Apple Silicon) didn't catch it — Mac container runtimes emulate amd64.

Caught live on the prod dual-region Graviton burn (gateway CrashLoopBackOff, both regions).

## Fix
Parallel arm64 chain; amd64/ECR path byte-for-byte untouched:
- `gateway_go/cmd/gateway/BUILD.bazel`: + `gateway_linux_arm64` (`go_cross_binary`, platform linux_arm64).
- `packaging/gateway/BUILD.bazel`: + `gateway_files_arm64`/`gateway_layer_arm64`/`image_arm64` (base `@distroless_static_linux_arm64_v8`)/`image_arm64_load`/`push_onprem`.
- `release-onprem-image.yml`: gateway build → `:image_arm64`, push → `:push_onprem`. `release-staging-image.yml` (amd64/ECR) untouched.

`bazel query` confirms targets resolve + arch isolation. ECR/staging amd64 path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc3HC4QvWtg4UH8EQqnH4i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ARM64 architecture support for the gateway component, enabling deployment on ARM64 systems.
  * Updated the release pipeline to properly build, package, and distribute ARM64 gateway images for on-premises deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->