### PR TITLE
fix(ci): gate staging suites on a public HTTP liveness probe, not an AWS proxy

### DIFF
--- a/.github/workflows/nightly-cognito-integration.yml
+++ b/.github/workflows/nightly-cognito-integration.yml
@@ -62,58 +62,64 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      # AWS OIDC: STS AssumeRoleWithWebIdentity → temporary creds.
-      # The configure-aws-credentials action exports them as
+      # Liveness gate (credential-free): before assuming any AWS role, probe
+      # the PUBLIC Cognito OIDC discovery document to decide whether staging's
+      # user pool still exists. No AWS OIDC/IAM/KMS needed. Note the host
+      # cognito-idp.<region>.amazonaws.com is AWS-owned and always up, so the
+      # "down" signal here is an HTTP 4xx (pool deleted), NOT a transport
+      # failure (contrast the gateway /healthz probe in postdeploy-e2e.yml,
+      # whose host is staging-owned and disappears on teardown):
+      #   - COGNITO_AUTHORITY unset → fork without staging → green skip
+      #   - HTTP 200 → pool exists → assume role and run the integration test
+      #   - HTTP 4xx → pool deleted (staging torn down) → green skip
+      #   - transport failure or 5xx → genuine anomaly → red
+      #
+      # This replaces an SSM get-parameter probe: the /aegis/staging/cognito/*
+      # params are written by a manual operator step (not Terraform), so they
+      # orphan on teardown and could not reliably signal "staging is down".
+      - name: Preflight — is staging Cognito up?
+        id: preflight
+        env:
+          COGNITO_AUTHORITY: ${{ vars.COGNITO_AUTHORITY }}
+        run: |
+          set -uo pipefail
+          if [ -z "${COGNITO_AUTHORITY:-}" ]; then
+            echo "staging_up=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Nightly Cognito integration skipped::vars.COGNITO_AUTHORITY unset — no staging Cognito pool configured (fork-friendly default). Skipping."
+            exit 0
+          fi
+          URL="${COGNITO_AUTHORITY%/}/.well-known/openid-configuration"
+          # -sS: quiet but show transport errors; no -f, so we read the status
+          # code ourselves and classify down (4xx) vs broken (5xx/transport).
+          HTTP=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$URL" 2>/dev/null)
+          RC=$?
+          if [ "$RC" -ne 0 ]; then
+            echo "::error title=Cognito OIDC endpoint unreachable::Could not reach ${URL} (curl exit ${RC}). cognito-idp.<region>.amazonaws.com is normally always up, so this is a real network/AWS anomaly — failing." >&2
+            exit 1
+          elif [ "$HTTP" = "200" ]; then
+            echo "staging_up=true" >> "$GITHUB_OUTPUT"
+            echo "Cognito OIDC discovery at ${URL} returned 200 — pool is up; running integration test."
+          elif [ "$HTTP" -ge 400 ] && [ "$HTTP" -lt 500 ]; then
+            echo "staging_up=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Nightly Cognito integration skipped::Cognito OIDC discovery returned HTTP ${HTTP} — staging user pool is gone (torn down). Skipping. Bring staging up (and refresh vars.COGNITO_AUTHORITY) to re-enable."
+          else
+            echo "::error title=Cognito OIDC endpoint error::${URL} returned HTTP ${HTTP} (expected 200 or 4xx). Unexpected server-side error — failing so it is visible." >&2
+            exit 1
+          fi
+
+      # AWS OIDC: STS AssumeRoleWithWebIdentity → temporary creds. Only after
+      # the credential-free liveness gate confirms the pool is up. The
+      # configure-aws-credentials action exports them as
       # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN
       # env vars; bazel test forwards them via env_inherit in
       # gateway_go/internal/auth/BUILD.bazel.
       - name: Configure AWS credentials (OIDC)
+        if: steps.preflight.outputs.staging_up == 'true'
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ env.COGNITO_INTEGRATION_ROLE_ARN }}
           role-session-name: aegis-core-cognito-integration-${{ github.run_id }}
-
-      # Self-gating: staging is ephemeral — brought up for verification then torn down to $0.
-      # If the staging Cognito SSM parameter is absent, skip all tests with a green result.
-      # ParameterNotFound = staging is down → green skip.
-      # Any other AWS API error (permissions, network, throttle) = real failure → red.
-      #
-      # We probe the SSM parameter /aegis/staging/cognito/user-pool-id rather than
-      # cognito-idp:list-user-pools: the integration role is scoped to ssm:GetParameter[s]
-      # on /aegis/staging/cognito/* but NOT to cognito-idp:ListUserPools, so the
-      # list-user-pools probe failed with AccessDeniedException under `set -e` before the
-      # skip branch could run (the guard never reached its "absent → skip" path). The SSM
-      # parameter is the canonical signal that staging is up — it's torn down with the rest
-      # of staging — and GetParameter is already in the role policy.
-      - name: Preflight — check staging Cognito pool exists
-        id: preflight
-        run: |
-          set -uo pipefail
-          # No `set -e`: we classify the probe's exit explicitly so a clean
-          # ParameterNotFound becomes a green skip while real API errors stay red.
-          # We query only Parameter.Name (never the value), so this is an
-          # existence check — but `--with-decryption` is required by the
-          # ssm-with-decryption-guard pre-commit hook (Incident 16). The role
-          # holds kms:Decrypt on alias/aegis-staging-secrets, and a missing
-          # parameter returns ParameterNotFound before KMS is ever invoked, so
-          # the skip path is unaffected.
-          if PROBE=$(aws ssm get-parameter \
-              --name /aegis/staging/cognito/user-pool-id \
-              --with-decryption \
-              --region "$AWS_REGION" \
-              --query 'Parameter.Name' \
-              --output text 2>&1); then
-            echo "cognito_present=true" >> "$GITHUB_OUTPUT"
-            echo "Staging Cognito SSM parameter present — proceeding with integration tests."
-          elif printf '%s' "$PROBE" | grep -q 'ParameterNotFound'; then
-            echo "cognito_present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Nightly Cognito integration skipped::Staging Cognito absent — skipping nightly integration (staging is torn down). Re-enable tests by bringing staging back up."
-          else
-            echo "::error title=Cognito preflight probe failed::SSM get-parameter on /aegis/staging/cognito/user-pool-id failed with a non-NotFound error (likely IAM, KMS, network, or throttle). Raw CLI output below." >&2
-            printf '%s\n' "$PROBE" >&2
-            exit 1
-          fi
 
       # Read live values from SSM PS rather than hard-coding the
       # Cognito IDs into the workflow. Two reasons per ldz #76 §A:
@@ -122,7 +128,7 @@ jobs:
       # the wrong place for them to live if they ever rotate.
       - name: Read Cognito IDs from SSM Parameter Store
         id: ssm
-        if: steps.preflight.outputs.cognito_present == 'true'
+        if: steps.preflight.outputs.staging_up == 'true'
         run: |
           set -euo pipefail
           # The Cognito SSM parameters are stored as `SecureString` (KMS
@@ -176,7 +182,7 @@ jobs:
       # their cost is sub-second and runs as a free regression check
       # on the same nightly cadence.
       - name: Cache Bazel
-        if: steps.preflight.outputs.cognito_present == 'true'
+        if: steps.preflight.outputs.staging_up == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
@@ -187,7 +193,7 @@ jobs:
             bazel-cognito-integration-${{ runner.os }}-
 
       - name: Run auth integration test against live Cognito
-        if: steps.preflight.outputs.cognito_present == 'true'
+        if: steps.preflight.outputs.staging_up == 'true'
         run: |
           set -euo pipefail
           ./tools/bazelisk/bazelisk test \
@@ -199,10 +205,10 @@ jobs:
       # If the test failed, surface a workflow annotation pointing at
       # the most likely causes — operator triaging the morning
       # alert shouldn't have to re-derive the failure-mode taxonomy.
-      # Guard with cognito_present so this hint only fires for real
+      # Guard with staging_up so this hint only fires for real
       # test failures, not for the clean "staging is down" skip path.
       - name: Failure triage hint
-        if: failure() && steps.preflight.outputs.cognito_present == 'true'
+        if: failure() && steps.preflight.outputs.staging_up == 'true'
         run: |
           cat <<'EOF' >&2
           ::error title=Cognito integration failed::

--- a/.github/workflows/nightly-cognito-integration.yml
+++ b/.github/workflows/nightly-cognito-integration.yml
@@ -91,10 +91,20 @@ jobs:
           URL="${COGNITO_AUTHORITY%/}/.well-known/openid-configuration"
           # -sS: quiet but show transport errors; no -f, so we read the status
           # code ourselves and classify down (4xx) vs broken (5xx/transport).
-          HTTP=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$URL" 2>/dev/null)
-          RC=$?
+          #
+          # Retry transport failures (RC != 0) up to 3 attempts before treating
+          # them as a hard anomaly: this host is AWS-owned and always up, so a
+          # transport failure is rare — but a single transient runner/DNS blip
+          # must not red the nightly. Any HTTP response ends the loop at once.
+          HTTP=000; RC=0
+          for attempt in 1 2 3; do
+            HTTP=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$URL" 2>/dev/null)
+            RC=$?
+            [ "$RC" -eq 0 ] && break
+            [ "$attempt" -lt 3 ] && { echo "Probe attempt ${attempt} failed (curl exit ${RC}); retrying…"; sleep 5; }
+          done
           if [ "$RC" -ne 0 ]; then
-            echo "::error title=Cognito OIDC endpoint unreachable::Could not reach ${URL} (curl exit ${RC}). cognito-idp.<region>.amazonaws.com is normally always up, so this is a real network/AWS anomaly — failing." >&2
+            echo "::error title=Cognito OIDC endpoint unreachable::Could not reach ${URL} after 3 attempts (curl exit ${RC}). cognito-idp.<region>.amazonaws.com is normally always up, so this is a real network/AWS anomaly — failing." >&2
             exit 1
           elif [ "$HTTP" = "200" ]; then
             echo "staging_up=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/postdeploy-e2e.yml
+++ b/.github/workflows/postdeploy-e2e.yml
@@ -109,11 +109,22 @@ jobs:
           # -sS: quiet but show transport errors; no -f, so we read the
           # status code ourselves and distinguish "down" (no connection)
           # from "broken" (connected, non-200).
-          HTTP=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$URL" 2>/dev/null)
-          RC=$?
+          #
+          # Retry transport failures (RC != 0) up to 3 attempts before
+          # concluding "down": a single transient runner/DNS blip must not
+          # produce a false-green skip while staging is actually up. Any HTTP
+          # response (even an error code) ends the loop immediately — that's
+          # a real answer to classify, not a transport failure.
+          HTTP=000; RC=0
+          for attempt in 1 2 3; do
+            HTTP=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$URL" 2>/dev/null)
+            RC=$?
+            [ "$RC" -eq 0 ] && break
+            [ "$attempt" -lt 3 ] && { echo "Probe attempt ${attempt} failed (curl exit ${RC}); retrying…"; sleep 5; }
+          done
           if [ "$RC" -ne 0 ]; then
             echo "staging_up=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Post-deploy E2E smoke skipped::Gateway ${URL} unreachable (curl exit ${RC}) — staging is torn down. Skipping. Bring staging up to re-enable."
+            echo "::notice title=Post-deploy E2E smoke skipped::Gateway ${URL} unreachable after 3 attempts (curl exit ${RC}) — staging is torn down. Skipping. Bring staging up to re-enable."
           elif [ "$HTTP" = "200" ]; then
             echo "staging_up=true" >> "$GITHUB_OUTPUT"
             echo "Gateway ${URL} returned 200 — staging is up; running E2E smoke tests."

--- a/.github/workflows/postdeploy-e2e.yml
+++ b/.github/workflows/postdeploy-e2e.yml
@@ -20,15 +20,21 @@ name: Post-deploy E2E smoke
 #     served by S3 + CloudFront per ADR-0027. Forks that haven't populated
 #     FRONTEND_DOMAIN see the job skip cleanly with operator guidance.
 #
-#   Layer 2 — staging Cognito existence (ephemeral-environment gate):
+#   Layer 2 — staging liveness (ephemeral-environment gate):
 #     Staging is ephemeral — brought up for verification then torn to $0.
 #     Even when FRONTEND_DOMAIN is set, the staging environment may be
-#     down. After AWS auth, we probe the SSM parameter
-#     /aegis/staging/cognito/user-pool-id (torn down with staging).
-#     ParameterNotFound → green skip with a ::notice annotation. A real
-#     AWS API error (auth failure, network, throttle) propagates as red
-#     so infra problems are never masked. This mirrors the pattern in
-#     nightly-cognito-integration.yml.
+#     down. We probe the PUBLIC gateway health endpoint directly —
+#     `https://${GATEWAY_DOMAIN}/healthz` — instead of an AWS-internal
+#     proxy. This is credential-free (no OIDC/IAM/KMS) and tests the
+#     actual deployed surface. curl's outcome gives a clean three-way:
+#       - transport failure (DNS/refused/timeout) → staging is gone → green skip
+#       - HTTP 200 → staging up & healthy → run the smoke suite
+#       - reachable but non-200 → staging up but broken → red
+#     Why not the SSM probe it replaced: the /aegis/staging/cognito/*
+#     params are written by a manual operator step (not Terraform), so
+#     they orphan on teardown — ParameterNotFound was not a reliable
+#     "staging is down" signal. A public liveness probe has no such proxy
+#     gap. This mirrors the gate in nightly-cognito-integration.yml.
 #
 # Why nightly (not per-commit): post-deploy E2E tests the *deployed*
 # surface, not the pre-merge code. Running it per-commit would test
@@ -53,14 +59,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  id-token: write # OIDC token exchange to AWS STS (preflight Cognito probe)
-  contents: read
-
-env:
-  AWS_REGION: eu-central-1
-  # Same role as nightly-cognito-integration — cognito-idp:list-user-pools
-  # is the read-only probe used in the preflight step below.
-  COGNITO_INTEGRATION_ROLE_ARN: arn:aws:iam::251774439261:role/github-actions-aegis-core-cognito-integration
+  contents: read # checkout only — the liveness gate is a public, unauthenticated curl
 
 jobs:
   playwright:
@@ -87,75 +86,52 @@ jobs:
             echo "url=https://${FRONTEND_DOMAIN}" >> "$GITHUB_OUTPUT"
           fi
 
-      # AWS OIDC: STS AssumeRoleWithWebIdentity → temporary creds.
-      # Only needed for the preflight Cognito probe; skipped entirely
-      # when FRONTEND_DOMAIN is unset (fork path).
-      - name: Configure AWS credentials (OIDC)
-        if: steps.gate.outputs.should_run == 'true'
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
-        with:
-          aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: ${{ env.COGNITO_INTEGRATION_ROLE_ARN }}
-          role-session-name: aegis-core-postdeploy-e2e-${{ github.run_id }}
-
-      # Self-gating: staging is ephemeral — brought up for verification
-      # then torn down to $0. If the staging Cognito SSM parameter is
-      # absent, skip all tests with a green result rather than failing
-      # against a non-existent environment.
-      #
-      # ParameterNotFound = staging is down → green skip. Any other AWS
-      # API error (permissions, network, throttle) propagates as red so
-      # infra failures are never masked.
-      #
-      # We probe the SSM parameter /aegis/staging/cognito/user-pool-id
-      # rather than cognito-idp:list-user-pools: the integration role is
-      # scoped to ssm:GetParameter[s] on /aegis/staging/cognito/* but NOT
-      # to cognito-idp:ListUserPools, so the list-user-pools probe failed
-      # with AccessDeniedException under `set -e` before the skip branch
-      # could run. GetParameter is already in the role policy and the
-      # parameter is torn down with the rest of staging.
-      #
-      # Mirrors the preflight in nightly-cognito-integration.yml.
-      - name: Preflight — check staging Cognito pool exists
+      # Liveness gate (credential-free): probe the PUBLIC gateway health
+      # endpoint to decide whether staging is actually serving traffic.
+      # No AWS OIDC/IAM/KMS — /healthz is unauthenticated. curl's outcome
+      # classifies three ways:
+      #   - transport failure (DNS/refused/timeout, exit != 0) → staging
+      #     gone (teardown removed DNS + ALB) → green skip
+      #   - HTTP 200 → staging up & healthy → run the smoke suite
+      #   - reachable but non-200 → staging up but broken → red
+      - name: Preflight — is staging serving?
         id: preflight
         if: steps.gate.outputs.should_run == 'true'
+        env:
+          GATEWAY_DOMAIN: ${{ vars.GATEWAY_DOMAIN }}
         run: |
           set -uo pipefail
-          # No `set -e`: classify the probe's exit explicitly so a clean
-          # ParameterNotFound becomes a green skip while real API errors stay red.
-          # We query only Parameter.Name (never the value), so this is an
-          # existence check — but `--with-decryption` is required by the
-          # ssm-with-decryption-guard pre-commit hook (Incident 16). The role
-          # holds kms:Decrypt on alias/aegis-staging-secrets, and a missing
-          # parameter returns ParameterNotFound before KMS is ever invoked, so
-          # the skip path is unaffected.
-          if PROBE=$(aws ssm get-parameter \
-              --name /aegis/staging/cognito/user-pool-id \
-              --with-decryption \
-              --region "$AWS_REGION" \
-              --query 'Parameter.Name' \
-              --output text 2>&1); then
-            echo "cognito_present=true" >> "$GITHUB_OUTPUT"
-            echo "Staging Cognito SSM parameter present — proceeding with E2E smoke tests."
-          elif printf '%s' "$PROBE" | grep -q 'ParameterNotFound'; then
-            echo "cognito_present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Post-deploy E2E smoke skipped::Staging Cognito absent — skipping post-deploy E2E (staging is torn down). Re-enable tests by bringing staging back up."
+          if [ -z "${GATEWAY_DOMAIN:-}" ]; then
+            echo "::error title=GATEWAY_DOMAIN unset::Set repository variable GATEWAY_DOMAIN (e.g. aegis-api.staging.aws.binhsu.org) so the liveness probe can reach the gateway."
+            exit 1
+          fi
+          URL="https://${GATEWAY_DOMAIN}/healthz"
+          # -sS: quiet but show transport errors; no -f, so we read the
+          # status code ourselves and distinguish "down" (no connection)
+          # from "broken" (connected, non-200).
+          HTTP=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$URL" 2>/dev/null)
+          RC=$?
+          if [ "$RC" -ne 0 ]; then
+            echo "staging_up=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Post-deploy E2E smoke skipped::Gateway ${URL} unreachable (curl exit ${RC}) — staging is torn down. Skipping. Bring staging up to re-enable."
+          elif [ "$HTTP" = "200" ]; then
+            echo "staging_up=true" >> "$GITHUB_OUTPUT"
+            echo "Gateway ${URL} returned 200 — staging is up; running E2E smoke tests."
           else
-            echo "::error title=Cognito preflight probe failed::SSM get-parameter on /aegis/staging/cognito/user-pool-id failed with a non-NotFound error (likely IAM, KMS, network, or throttle). Raw CLI output below." >&2
-            printf '%s\n' "$PROBE" >&2
+            echo "::error title=Gateway unhealthy::${URL} is reachable but returned HTTP ${HTTP} (expected 200). Staging is up but the gateway is unhealthy — failing so the problem is visible." >&2
             exit 1
           fi
 
       - name: Install frontend deps
-        if: steps.preflight.outputs.cognito_present == 'true'
+        if: steps.preflight.outputs.staging_up == 'true'
         run: ./tools/scripts/frontend.sh install
 
       - name: Install Playwright browsers
-        if: steps.preflight.outputs.cognito_present == 'true'
+        if: steps.preflight.outputs.staging_up == 'true'
         run: ./tools/scripts/frontend.sh e2e:install
 
       - name: Run post-deploy spec
-        if: steps.preflight.outputs.cognito_present == 'true'
+        if: steps.preflight.outputs.staging_up == 'true'
         env:
           AEGIS_POSTDEPLOY_URL: ${{ steps.gate.outputs.url }}
           # Forward CI=true so the Playwright config applies its
@@ -171,7 +147,7 @@ jobs:
             -g "post-deploy happy-path smoke"
 
       - name: Upload Playwright report on failure
-        if: failure() && steps.preflight.outputs.cognito_present == 'true'
+        if: failure() && steps.preflight.outputs.staging_up == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report-postdeploy


### PR DESCRIPTION
## Problem

The skip-if-staging-is-down gate in `nightly-cognito-integration` and `postdeploy-e2e` probed an **AWS-internal proxy** (an SSM parameter) to infer whether staging is up. The live env on `main` (after #166) revealed why that's unreliable:

- Teardown **destroys the KMS key** (`alias/aegis-staging-secrets`) but **leaves the `/aegis/staging/cognito/*` params orphaned** — they're written by a *manual operator step*, not Terraform.
- So `get-parameter --with-decryption` (mandated by the Incident-16 pre-commit hook) hit `kms:Decrypt` on a deleted key → `AccessDeniedException` → **red**.
- Worse, KMS returns an **identical** `AccessDeniedException` whether the key is *gone* (staging down) or a *policy denies* it (real misconfig) — so the proxy couldn't even distinguish "down" from "broken."

## Fix — probe the real thing

Both gates now `curl` a **public, unauthenticated** endpoint (no OIDC/IAM/KMS) and classify by **transport-vs-status**, which gives the clean three-way the KMS probe couldn't:

### `postdeploy-e2e` — `curl https://${GATEWAY_DOMAIN}/healthz`
| Outcome | Meaning | Result |
|---|---|---|
| transport failure (DNS/refused/timeout) | staging gone | 🟢 skip |
| HTTP 200 | up & healthy | run suite |
| reachable, non-200 | up but broken | 🔴 red |

Removes AWS credentials from the workflow **entirely** (the gate was the only consumer) — dropped `id-token` permission + AWS env block.

### `nightly-cognito-integration` — `curl ${COGNITO_AUTHORITY}/.well-known/openid-configuration`
The host `cognito-idp.<region>.amazonaws.com` is AWS-owned and always up, so the down-signal is an HTTP **4xx** (pool deleted), not a transport failure:

| Outcome | Meaning | Result |
|---|---|---|
| `COGNITO_AUTHORITY` unset | fork w/o staging | 🟢 skip |
| HTTP 200 | pool up | assume role + run test |
| HTTP 4xx | pool gone | 🟢 skip |
| transport failure / 5xx | genuine anomaly | 🔴 red |

AWS creds are assumed **only after** the gate confirms the pool is up. The AWS test body (`AdminCreateUser` etc.) is unchanged.

All hostnames are plain (non-secret) GitHub repo `vars.*` (`GATEWAY_DOMAIN`, `COGNITO_AUTHORITY`), readable without AWS auth.

## Verification
- Both workflow YAMLs parse; all pre-commit hooks pass (incl. `ssm-with-decryption-guard`).
- BVA-tested both classifiers: transport-fail / 200 / 4xx / 5xx / unset-var / trailing-slash URL composition → all classify correctly.
- Live validation on `main` after merge (OIDC trust is main-only, so branch dispatch can't fully validate — but the gate is now credential-free, so the gateway probe validates from anywhere).

Supersedes the SSM probe added in #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use HTTP health checks for staging environment availability instead of credential-based checks across nightly integration and post-deploy tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->