### PR TITLE
fix(ci): set +e in liveness probes — GitHub's bash -e killed the skip path

### DIFF
--- a/.github/workflows/nightly-cognito-integration.yml
+++ b/.github/workflows/nightly-cognito-integration.yml
@@ -83,6 +83,12 @@ jobs:
           COGNITO_AUTHORITY: ${{ vars.COGNITO_AUTHORITY }}
         run: |
           set -uo pipefail
+          # GitHub's default step shell is `bash -e {0}`, so errexit is ON even
+          # though we never set it. Turn it OFF here: a failing `HTTP=$(curl …)`
+          # would otherwise kill the step on the first attempt — defeating the
+          # retry loop and the transport-failure classification below. We read
+          # curl's exit code explicitly instead of letting -e act on it.
+          set +e
           if [ -z "${COGNITO_AUTHORITY:-}" ]; then
             echo "staging_up=false" >> "$GITHUB_OUTPUT"
             echo "::notice title=Nightly Cognito integration skipped::vars.COGNITO_AUTHORITY unset — no staging Cognito pool configured (fork-friendly default). Skipping."

--- a/.github/workflows/postdeploy-e2e.yml
+++ b/.github/workflows/postdeploy-e2e.yml
@@ -101,6 +101,13 @@ jobs:
           GATEWAY_DOMAIN: ${{ vars.GATEWAY_DOMAIN }}
         run: |
           set -uo pipefail
+          # GitHub's default step shell is `bash -e {0}`, so errexit is ON even
+          # though we never set it. Turn it OFF here: a failing `HTTP=$(curl …)`
+          # (e.g. DNS-fail when staging is torn down) would otherwise kill the
+          # step on the first attempt — defeating the retry loop and the
+          # transport-failure → skip classification below. We read curl's exit
+          # code explicitly instead of letting -e act on it.
+          set +e
           if [ -z "${GATEWAY_DOMAIN:-}" ]; then
             echo "::error title=GATEWAY_DOMAIN unset::Set repository variable GATEWAY_DOMAIN (e.g. aegis-api.staging.aws.binhsu.org) so the liveness probe can reach the gateway."
             exit 1


### PR DESCRIPTION
## Problem

The HTTP liveness gates from #167 went **red** against a torn-down staging instead of green-skipping (caught on the post-merge main dispatch: nightly passed, postdeploy failed with `exit code 6`).

**Root cause:** GitHub Actions runs `run:` blocks under **`bash -e {0}`** — errexit is ON even though the script only does `set -uo pipefail`. So the probe's `HTTP=$(curl …)`, when curl fails (DNS-fail with staging down → exit 6), trips `-e` and **kills the step on the first attempt** — before `RC=$?`, the retry loop, or the transport-failure → skip classification ever run.

The nightly Cognito gate has the **same latent bug**; it only passed because its curl *succeeded* (HTTP 404, which is a clean "pool gone → skip").

## Fix

Add `set +e` to both preflight steps so curl's exit code is read explicitly (as the classification already assumes). One line + a comment each.

## Verification

End-to-end under `bash -e` (GitHub's actual shell) against the **real torn-down endpoints**:

```
postdeploy gateway: attempt 1 fail (rc 6) → retry → attempt 2 fail → SKIP (rc=6), step exit=0 ✓
nightly cognito:    HTTP 404 → SKIP, step exit=0 ✓
```

Both green via the skip path, and the retry loop now actually retries. YAML + all pre-commit hooks pass.

Follow-up to #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced resilience of continuous integration workflow health checks and deployment preflight verification steps. Improved error handling in deployment workflows to gracefully manage transient connectivity failures without causing premature step termination, ensuring configured retry mechanisms function as intended for deployment health verification, environment liveness monitoring, and staging integration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->