### PR TITLE
ci: fix Semgrep p/ci supply-chain package-manager findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,13 @@ updates:
     labels:
       - dependencies
       - github-actions
+    # 7-day cooldown: a newly published action tag/release could be a
+    # supply-chain compromise (Semgrep p/ci
+    # dependabot-missing-cooldown). Waiting a week before Dependabot
+    # proposes it lets a malicious release get caught/pulled upstream
+    # first.
+    cooldown:
+      default-days: 7
 
   # ---------------------------------------------------------------------------
   # Go modules (gateway_go/). grpc-go + protobuf-go bump frequently;
@@ -54,6 +61,11 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-major"
+    # 7-day cooldown — same supply-chain rationale as the
+    # github-actions block above (Semgrep p/ci
+    # dependabot-missing-cooldown).
+    cooldown:
+      default-days: 7
 
   # ---------------------------------------------------------------------------
   # NPM (frontend_web/). Vite and React moved fast; don't auto-open PRs
@@ -68,6 +80,12 @@ updates:
       - dependencies
       - frontend
     versioning-strategy: increase-if-necessary
+    # 7-day cooldown — same supply-chain rationale as above (Semgrep
+    # p/ci dependabot-missing-cooldown). npm's registry has the
+    # highest typosquat/compromised-maintainer volume of the four
+    # ecosystems here, so this is the block where it matters most.
+    cooldown:
+      default-days: 7
 
   # ---------------------------------------------------------------------------
   # Bazel MODULE.bazel deps. Dependabot has native bzlmod support.
@@ -87,6 +105,10 @@ updates:
       - dependency-name: "ggml"
       - dependency-name: "whisper_cpp"
       - dependency-name: "llama_cpp"
+    # 7-day cooldown — same supply-chain rationale as above (Semgrep
+    # p/ci dependabot-missing-cooldown).
+    cooldown:
+      default-days: 7
 # Python pip stanza removed alongside tools/rag/ deletion — the engine
 # will own both seed-time and query-time bge-m3 embedding per
 # ADR-0020 (forthcoming), so the repo no longer has a Python runtime

--- a/.npmrc
+++ b/.npmrc
@@ -10,5 +10,12 @@
 #
 # `virtual-store-dir` likewise pins the virtual-store location
 # (normally node_modules/.pnpm) to an in-repo path for symmetry.
+#
+# `min-release-age` (npm >=11.10) makes npm refuse to resolve a package
+# version published fewer than 7 days ago — a cooldown window against
+# newly-published malicious/typosquat releases and compromised-maintainer
+# pushes (Semgrep p/ci npm-missing-minimum-release-age). It is a no-op
+# warning on older npm, so it is safe to set ahead of an upgrade.
 
 store-dir=.pnpm-store
+min-release-age=7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,26 @@
 
 packages:
   - "frontend_web"
+
+# --- Supply-chain hardening (Semgrep p/ci package_managers.pnpm.*) ---
+# These three settings were added to pnpm in v10.16/v10.21/v10.26. The
+# repo currently pins `pnpm@8.6.7` (package.json packageManager field,
+# ADR-0015 — lockfileVersion 6.0, the format aspect_rules_js's
+# npm_translate_lock expects). pnpm 8.6.7 silently ignores unknown
+# workspace-config keys (verified: `pnpm install` with these three
+# keys present still runs clean, no error), so setting them now is a
+# harmless forward-compatible no-op that activates automatically once
+# the repo upgrades past pnpm v10.26 — no follow-up edit needed here
+# at that point.
+#
+# minimumReleaseAge: reject a dependency version published less than
+# 7 days (10080 minutes) ago — same cooldown rationale as .npmrc's
+# min-release-age and dependabot.yml's cooldown blocks.
+minimumReleaseAge: 10080
+# trustPolicy: refuse an update that would downgrade another
+# package's declared security settings (e.g. strip a postinstall
+# guard) — blocks one known supply-chain-takeover pattern.
+trustPolicy: no-downgrade
+# blockExoticSubdeps: refuse transitive deps resolved from non-registry
+# sources (git/tarball URLs), which bypass npm registry vetting.
+blockExoticSubdeps: true


### PR DESCRIPTION
## Summary

The **Semgrep SAST scan** job in `ci-baseline.yml` (`semgrep scan --config p/ci --error --metrics off`) has no `|| true` guard — despite the comment above it describing all Phase 4b scanners as advisory-only, this one hard-fails and blocks the check. It was failing with **8 blocking findings across 4 files**, none touching application code — all are `p/ci`'s package-manager supply-chain-hardening rules flagging config gaps in dependabot.yml / .npmrc / pnpm-workspace.yaml.

Investigated via the most recent failed run (`gh run view <id> --log-failed`, run 29783202321) to get the exact rule IDs and files.

## Findings and disposition

| File | Rule | Verdict |
|---|---|---|
| `.github/dependabot.yml` | `dependabot-missing-cooldown` | Real gap — fixed |
| `.npmrc` | `npm-missing-minimum-release-age` | Real gap — fixed |
| `pnpm-workspace.yaml` | `pnpm-trust-policy` | Real gap — fixed |
| `pnpm-workspace.yaml` | `pnpm-minimum-release-age` | Real gap — fixed |
| `pnpm-workspace.yaml` | `pnpm-block-exotic-sub-dependencies` | Real gap — fixed |

All 5 are genuine hardening gaps, not false positives on unrelated config, so this fixes root cause in each file rather than suppressing. No `nosemgrep` / `.semgrepignore` used anywhere.

## Changes

1. **`.github/dependabot.yml`** — added `cooldown: {default-days: 7}` to all 4 active `updates` entries (github-actions, gomod, npm, bazel). This is a Dependabot server-side feature; it works regardless of local tool versions.
2. **`.npmrc`** — added `min-release-age=7`. Verified the exact config key against npm CLI docs (it's `min-release-age`, not `minimum-release-age`). Older npm just warns and ignores unknown config, so this is safe ahead of an npm upgrade.
3. **`pnpm-workspace.yaml`** — added `minimumReleaseAge: 10080` (minutes), `trustPolicy: no-downgrade`, `blockExoticSubdeps: true`.
   - **Important caveat, called out in-file:** these three pnpm settings require pnpm v10.16 / v10.21 / v10.26 respectively. This repo pins `pnpm@8.6.7` (`package.json` `packageManager`, ADR-0015 — needed for `lockfileVersion: "6.0"` compatibility with `aspect_rules_js`'s `npm_translate_lock`). I verified pnpm 8.6.7 silently ignores unrecognized `pnpm-workspace.yaml` keys (`pnpm install` ran clean with all three present, no error/warning, lockfile untouched) — so this is a harmless, forward-compatible no-op today that activates automatically the moment the repo upgrades pnpm past v10.26, no follow-up edit required.

## Verification

Ran the exact CI command locally against this branch:
```
uvx --from 'semgrep~=1.95' semgrep scan --config p/ci --error --metrics off
```
Result: **0 findings** (down from 8), same ruleset/version pin as the CI job.

## Test plan

- [ ] CI "Semgrep SAST scan" job goes green on this PR
- [ ] Confirm no new findings introduced elsewhere by the added config

Depends on nothing; this is independent of the ws/react-router dependency bump PR (#180). Not merging — opening for review per repo convention.