### PR TITLE
ci: auto-merge Dependabot patch/minor PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+# Auto-merge Dependabot PRs once required checks pass.
+# Scope guard: only patch + minor updates auto-merge. Major bumps are held for manual review.
+name: Dependabot auto-merge
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  auto-merge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+      - name: Approve and enable auto-merge (patch + minor only)
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependabot-auto-merge.yml`: approves and enables squash auto-merge on Dependabot PRs whose `update-type` (via `dependabot/fetch-metadata`) is `semver-patch` or `semver-minor`. Major version bumps are deliberately excluded and left for manual review — see the scope-guard comment at the top of the file.

Also enabled the repo setting `allow_auto_merge` (`gh api --method PATCH /repos/BinHsu/aegis-core -F allow_auto_merge=true`), which is a prerequisite for `gh pr merge --auto` to work at all — it was `false` before this change.

## How this interacts with branch protection

`gh pr merge --auto` only *schedules* the merge; GitHub still blocks it until every required status check reports green. This workflow does not bypass or weaken branch protection.

**This repo currently has a required check that hard-fails independent of app code**: "Semgrep SAST scan" in `ci-baseline.yml` has no `|| true` guard and is failing on 8 pnpm/dependabot config findings unrelated to the Dependabot PRs it will be evaluating auto-merge on. See PR #181, which fixes those findings at the root (dependabot.yml cooldown, .npmrc min-release-age, pnpm-workspace.yaml trustPolicy/minimumReleaseAge/blockExoticSubdeps).

**Until #181 merges, Dependabot patch/minor PRs will be approved and queued for auto-merge by this workflow but will keep sitting unmerged**, same as they do today, waiting on the Semgrep check — this workflow becomes fully effective once that check is green.

## Test plan

- [ ] Merge #181 first (or independently) so the Semgrep required check is green
- [ ] Confirm a live Dependabot patch/minor PR gets auto-approved + queued for auto-merge by this workflow
- [ ] Confirm a Dependabot major-bump PR is *not* touched by this workflow (left for manual review)

Not merging — opening for review per repo convention.