### PR TITLE
fix(ci): SHA-pin dependabot/fetch-metadata (Semgrep mutable-action-tag)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
       - name: Approve and enable auto-merge (patch + minor only)
         if: >-
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||


### PR DESCRIPTION
The auto-merge workflow added in #182 used `dependabot/fetch-metadata@v2`, a mutable major tag. This repo's Semgrep `p/ci` ruleset enforces `github-actions-mutable-action-tag` (blocking), so `Semgrep SAST scan` went red on main after #182 merged.

Pin to the commit SHA `21025c7` (v2.5.0) with a version comment, per the repo's SHA-pinning standard. Restores Semgrep to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and security of automated dependency updates by pinning the metadata action to a specific version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->