### PR TITLE
ci: root the npm updater at the pnpm workspace root, guard lockfile format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,11 +68,30 @@ updates:
       default-days: 7
 
   # ---------------------------------------------------------------------------
-  # NPM (frontend_web/). Vite and React moved fast; don't auto-open PRs
-  # for every patch — monthly + patch-level only to keep signal high.
+  # NPM (frontend_web/, but rooted at "/"). Vite and React moved fast;
+  # don't auto-open PRs for every patch — monthly + patch-level only to
+  # keep signal high.
+  #
+  # directory is "/" and NOT "/frontend_web", even though frontend_web is
+  # the only workspace member. frontend_web is a pnpm workspace whose
+  # pnpm-lock.yaml and pnpm-workspace.yaml live at the repo root, not
+  # inside frontend_web/. The npm updater treats `directory` as its root
+  # and does not look above it, so pointed at "/frontend_web" it can edit
+  # frontend_web/package.json but has no lockfile in scope to update
+  # alongside it. The resulting PR carries a bumped manifest and a stale
+  # lockfile, which fails `pnpm install --frozen-lockfile` in CI every
+  # time.
+  #
+  # This is exactly what happened in PR #188 (@types/node ^20.19.0 ->
+  # ^26.1.1): Dependabot bumped frontend_web/package.json only, the root
+  # pnpm-lock.yaml didn't move, and "Frontend live-browser smoke
+  # (Playwright)" failed with ERR_PNPM_OUTDATED_LOCKFILE. Rooting the
+  # updater at "/" gives it visibility into the root lockfile so it can
+  # update both files together, same as it already does for the bazel and
+  # github-actions stanzas above.
   # ---------------------------------------------------------------------------
   - package-ecosystem: npm
-    directory: "/frontend_web"
+    directory: "/"
     schedule:
       interval: monthly
     open-pull-requests-limit: 3

--- a/.github/workflows/ci-baseline.yml
+++ b/.github/workflows/ci-baseline.yml
@@ -40,6 +40,60 @@ jobs:
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   # ---------------------------------------------------------------------------
+  # Lockfile format guard — cheap, fast-failing check that the repo-root
+  # pnpm-lock.yaml still declares lockfileVersion 6.0. Root package.json
+  # pins "packageManager": "pnpm@8.6.7", and ADR-0015 explains why: 6.0 is
+  # the lockfile format aspect_rules_js's npm_translate_lock expects. Both
+  # this workflow's "Install frontend deps (hermetic pnpm)" step and
+  # release-staging-frontend.yml consume this lockfile via Bazel.
+  #
+  # If the lockfile is ever regenerated with a pnpm newer than 8.6.7 (e.g.
+  # a Dependabot npm PR that runs its own pnpm), lockfileVersion drifts to
+  # 9.0 and the Bazel build breaks, not just frontend tests. No Bazel, no
+  # pnpm install, no network here — just a checkout and a grep, so this
+  # fails loud in seconds instead of surfacing later as a confusing Bazel
+  # error.
+  #
+  # The value match is tolerant of quoting: native pnpm@8.6.7 output is
+  # single-quoted (lockfileVersion: '6.0'), but the repo's prettier
+  # pre-commit hook rewrites it to double-quoted (lockfileVersion: "6.0")
+  # once it runs. Both are legitimate depending on whether prettier has
+  # touched the file yet, so the check accepts bare, single-quoted, or
+  # double-quoted "6.0" — but the value itself must match exactly
+  # ("16.0" or "6.01" still fail; this is not a substring match).
+  # ---------------------------------------------------------------------------
+  lockfile-format-guard:
+    name: Lockfile format guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Assert pnpm-lock.yaml is lockfileVersion 6.0
+        run: |
+          set -euo pipefail
+          file="pnpm-lock.yaml"
+          expected_desc='lockfileVersion 6.0 (bare, single-quoted, or double-quoted)'
+          if [ ! -f "$file" ]; then
+            echo "::error::${file} not found at repo root. Expected ${expected_desc}. Regenerate with pnpm@8.6.7 per ADR-0015 (docs/ADR/0015-hermetic-nodejs-via-aspect-rules-js.md)."
+            exit 1
+          fi
+          found=$(grep -m1 '^lockfileVersion:' "$file" || true)
+          if [ -z "$found" ]; then
+            echo "::error::${file} has no lockfileVersion line at all. Expected ${expected_desc}. Regenerate with pnpm@8.6.7 per ADR-0015 (docs/ADR/0015-hermetic-nodejs-via-aspect-rules-js.md)."
+            exit 1
+          fi
+          # Anchored to the whole line: cannot match a nested key, and
+          # cannot substring-match "16.0" / "6.01" — the value between
+          # the optional quotes must be exactly 6.0.
+          regex="^lockfileVersion:[[:space:]]*[\"']?6\.0[\"']?[[:space:]]*\$"
+          if ! printf '%s\n' "$found" | grep -Eq "$regex"; then
+            echo "::error::${file} lockfileVersion mismatch. Expected: ${expected_desc}. Found: ${found}. Regenerate the lockfile with pnpm@8.6.7 (root package.json packageManager pin) per ADR-0015 — a different lockfileVersion (e.g. 9.0 from a newer pnpm) breaks aspect_rules_js's npm_translate_lock and the Bazel build, not just the frontend tests."
+            exit 1
+          fi
+          echo "OK: ${file} declares ${expected_desc} (found: ${found})"
+
+  # ---------------------------------------------------------------------------
   # Secret scanning — redundant with GitHub push protection + pre-commit
   # gitleaks, but runs in CI for pull requests from forks where push
   # protection may not apply.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,21 @@ default_language_version:
 # (Surfaced 2026-07-29 during the protobuf-es v2 migration, once the
 # drift job's pathspec was corrected to actually cover this tree.)
 # Read-only hooks — gitleaks, check-yaml, buf lint — still see the files.
+#
+# pnpm-lock.yaml (repo root) is excluded the same way and for the same
+# reason: it is a generated file, and pnpm@8.6.7 is its tool of record
+# (ADR-0015, root package.json's packageManager pin), not Prettier.
+# Native pnpm output is single-quoted / single-line; Prettier rewrites it
+# to double-quoted / multi-line `resolution:` blocks. Once
+# .github/dependabot.yml's npm stanza is rooted at "/" so Dependabot can
+# author this file directly, an unexcluded rewriting hook would reformat
+# every Dependabot-authored lockfile and fail "Pre-commit hooks" in
+# ci-baseline.yml with "files were modified by this hook" — trading
+# ERR_PNPM_OUTDATED_LOCKFILE for a formatter red light on the same PRs.
+# Excluded from trailing-whitespace / end-of-file-fixer /
+# mixed-line-ending / prettier; still visible to check-yaml,
+# check-added-large-files, gitleaks, detect-private-key, and the other
+# read-only hooks, which only inspect and never rewrite.
 
 repos:
   # ---------------------------------------------------------------------------
@@ -35,11 +50,13 @@ repos:
     hooks:
       - id: trailing-whitespace
         # `\.md$` preserves Markdown line-break trailing spaces;
-        # frontend_web/src/gen/ is generated (see note above).
-        exclude: '(\.md$|^frontend_web/src/gen/)'
+        # frontend_web/src/gen/ and pnpm-lock.yaml are generated (see
+        # note above).
+        exclude: '(\.md$|^frontend_web/src/gen/|^pnpm-lock\.yaml$)'
       - id: end-of-file-fixer
         # protoc-gen-es emits a trailing blank line; leave it alone.
-        exclude: "^frontend_web/src/gen/"
+        # pnpm-lock.yaml is generated (see note above).
+        exclude: '(^frontend_web/src/gen/|^pnpm-lock\.yaml$)'
       - id: check-yaml
         args: ["--allow-multiple-documents"]
       - id: check-json
@@ -51,7 +68,8 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         args: ["--fix=lf"]
-        exclude: "^frontend_web/src/gen/"
+        # pnpm-lock.yaml is generated (see note above).
+        exclude: '(^frontend_web/src/gen/|^pnpm-lock\.yaml$)'
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
 
@@ -101,6 +119,7 @@ repos:
         exclude: |
           (?x)(
             ^frontend_web/src/gen/|
+            ^pnpm-lock\.yaml$|
             ^(
               docs/adr/.*\.md|
               ARCHITECTURE\.md|


### PR DESCRIPTION
## Why

Dependabot's npm stanza was rooted at `/frontend_web`, but `frontend_web` is a pnpm workspace member whose `pnpm-lock.yaml` and `pnpm-workspace.yaml` live at the repo root. The updater treats `directory` as its root and does not look above it, so it could bump `frontend_web/package.json` with no lockfile in scope to update alongside — structurally guaranteeing a stale lockfile on every npm PR.

**Incident:** PR #188 (`@types/node` `^20.19.0` -> `^26.1.1`). The manifest moved, the root lockfile did not, and *Frontend live-browser smoke (Playwright)* failed with `ERR_PNPM_OUTDATED_LOCKFILE`.

## What

Three coupled changes. The first alone only relocates the failure, which is why they ship together.

| File | Change |
|---|---|
| `.github/dependabot.yml` | npm `directory` `/frontend_web` -> `/` so the updater sees the root lockfile and rewrites both files together. Schedule, PR limit, labels, `versioning-strategy` and `cooldown` unchanged. |
| `.pre-commit-config.yaml` | Exclude root `pnpm-lock.yaml` from the four hooks that REWRITE content: `trailing-whitespace`, `end-of-file-fixer`, `mixed-line-ending`, `prettier`. |
| `.github/workflows/ci-baseline.yml` | New `lockfile-format-guard` job asserting the root lockfile still declares `lockfileVersion` 6.0. |

### Why the pre-commit exclusion is load-bearing

`pnpm@8.6.7` is this file's tool of record (ADR-0015), not Prettier. Native pnpm output is single-quoted and single-line; Prettier rewrites it to double-quoted multi-line `resolution:` blocks — a **measured 1438-line round trip**. Without the exclusion, every Dependabot-authored lockfile fails *Pre-commit hooks* with `files were modified by this hook`, trading `ERR_PNPM_OUTDATED_LOCKFILE` for a formatter red light on exactly the same PRs.

This follows the policy already stated in that file's header: generated files are excluded from rewriting hooks. Read-only hooks (`check-yaml`, `gitleaks`, `detect-private-key`, `check-added-large-files`) still see the lockfile. The line is rewrite-vs-inspect, not important-vs-not.

### Why the guard

Now that Dependabot authors the lockfile, a regeneration under a newer pnpm would silently drift it to `lockfileVersion: 9.0`, breaking `aspect_rules_js`'s `npm_translate_lock` and therefore the **Bazel build** — not just the frontend tests. Checkout plus a grep: no Bazel, no pnpm, no network, fails in seconds.

The match is quote-tolerant, because both `'6.0'` and `"6.0"` are legitimate depending on whether Prettier has run, but exact on the value.

## Verification

The guard's shell body was extracted programmatically from the workflow YAML (not hand-copied) and run against six fixtures:

| Case | Expected | Result |
|---|---|---|
| Real lockfile, `"6.0"` | pass | exit 0 |
| Native pnpm `'6.0'` | pass | exit 0 |
| `"9.0"` | fail | exit 1 |
| `"16.0"` (substring trap) | fail | exit 1 |
| `lockfileVersion` line stripped | fail | exit 1 |
| File absent | fail | exit 1 |

Each of the four exclude regexes was checked three ways: matches `pnpm-lock.yaml`; still matches what it excluded before (`frontend_web/src/gen/`, and the Markdown entries for `prettier`); and does NOT match files that must stay formatted (`frontend_web/src/main.tsx`, `frontend_web/package.json`, `pnpm-workspace.yaml`, `.github/workflows/ci-baseline.yml`). A hypothetical `frontend_web/pnpm-lock.yaml` stays formattable — only the root file is exempt.

All three YAML files parse, and `pre-commit run` over them passes with no hook rewriting anything.

## Follow-up, not in this PR

`main` has no branch protection (`gh api .../protection` returns 404), so this guard — and every other job in `ci-baseline.yml` — is currently advisory: a red check cannot block a merge. Making it a real gate needs `Lockfile format guard` and `Pre-commit hooks` set as required checks. Raised separately; it is repo governance, not a code change.

Companion: the stale lockfile on #188 is fixed by a commit pushed to that branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency update handling to keep package lockfiles synchronized and reduce frozen-lockfile installation failures.
  * Added automated validation to detect missing or incompatible lockfile formats before CI progresses.

* **Chores**
  * Prevented automated formatting and whitespace checks from modifying the package lockfile, preserving its generated format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->