### PR TITLE
ci: add merge_group trigger to CI Baseline ahead of the merge queue

### DIFF
--- a/.github/workflows/ci-baseline.yml
+++ b/.github/workflows/ci-baseline.yml
@@ -8,7 +8,17 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Required for GitHub merge queue. Every context in main-protection's
+  # required_status_checks list is a job in THIS workflow, so without a
+  # merge_group trigger a queued PR waits forever on checks that never
+  # run — the queue deadlocks rather than failing visibly. Adding the
+  # trigger must therefore land BEFORE the merge_queue rule is enabled.
+  merge_group:
+    types: [checks_requested]
 
+# github.ref is the queue's own gh-readonly-queue/... ref on merge_group
+# events, so each queued entry gets its own concurrency group and entries
+# do not cancel each other.
 concurrency:
   group: ci-baseline-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Prerequisite for enabling the merge queue on `main`.

All 11 contexts in `main-protection`'s `required_status_checks` are jobs in `ci-baseline.yml`, which triggered on `push` + `pull_request` only. Turning the queue on in that state **deadlocks** it — a queued PR waits on 11 checks that never run, showing "expected" indefinitely instead of failing visibly. So this lands first, the `merge_queue` rule second.

### Why a queue is wanted

`strict_required_status_checks_policy` is on, so every merge puts all other open PRs BEHIND, each needing update-branch plus a full CI re-run. With `Bazel unit tests` at ~10m and 13 open Dependabot PRs, clearing the backlog serially costs hours. A queue batches entries and validates them against the actual post-merge tree.

### Notes

- The step-level `github.event_name == 'pull_request'` guard on buf-breaking is intentionally left alone. It skips on `merge_group` (there is no PR base ref to diff against), but it is a *step*, so its job still reports and no required context goes missing.
- `concurrency` is unchanged: on `merge_group`, `github.ref` is the queue's own `gh-readonly-queue/...` ref, so entries get distinct groups and do not cancel one another.