### PR TITLE
chore: document maintenance freeze and pause version-update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@
 version: 2
 
 # =============================================================================
-# MAINTENANCE FREEZE (from 2026-07-31, expected to lift ~2026-Q1/Q2):
+# MAINTENANCE FREEZE (from 2026-07-31, expected to lift ~2027-Q1/Q2):
 # the owner is starting a new job and won't be able to tend this repo for six
 # months or more. Every `open-pull-requests-limit` below is set to 0 so
 # Dependabot stops opening version-update PRs — a public repo with dozens of

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,13 @@ version: 2
 # months or more. Every `open-pull-requests-limit` below is set to 0 so
 # Dependabot stops opening version-update PRs — a public repo with dozens of
 # unattended bot PRs piling up reads worse than one with the cadence
-# deliberately turned down. This does NOT touch security updates, which are a
-# separate GitHub mechanism (repo Settings → Code security → Dependabot
-# security updates) and keep firing regardless of this file. To resume normal
-# cadence, restore each entry's previous limit (noted inline) and delete this
-# block.
+# deliberately turned down. This does NOT touch security updates: those are a
+# separate GitHub mechanism, controlled in repo Settings → Code security →
+# Dependabot security updates, not in this file — this file cannot enable or
+# disable that setting. It is currently ON (verified 2026-07-31), so security
+# PRs keep flowing; if someone turns that setting off, they stop, independent
+# of anything here. To resume normal cadence, restore each entry's previous
+# limit (noted inline) and delete this block.
 # =============================================================================
 
 updates:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,10 @@
 version: 2
 
 # =============================================================================
-# MAINTENANCE FREEZE (from 2026-07-31, expected to lift ~2027-Q1/Q2):
-# the owner is starting a new job and won't be able to tend this repo for six
-# months or more. Every `open-pull-requests-limit` below is set to 0 so
+# MAINTENANCE FREEZE — in effect from the merge of this change (authored
+# 2026-07-31, expected to lift ~2027-Q1/Q2). The owner is starting a new job
+# and won't be able to tend this repo for six months or more. Every
+# `open-pull-requests-limit` below is set to 0 so
 # Dependabot stops opening version-update PRs — a public repo with dozens of
 # unattended bot PRs piling up reads worse than one with the cadence
 # deliberately turned down. This does NOT touch security updates: those are a

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,19 @@
 
 version: 2
 
+# =============================================================================
+# MAINTENANCE FREEZE (from 2026-07-31, expected to lift ~2026-Q1/Q2):
+# the owner is starting a new job and won't be able to tend this repo for six
+# months or more. Every `open-pull-requests-limit` below is set to 0 so
+# Dependabot stops opening version-update PRs — a public repo with dozens of
+# unattended bot PRs piling up reads worse than one with the cadence
+# deliberately turned down. This does NOT touch security updates, which are a
+# separate GitHub mechanism (repo Settings → Code security → Dependabot
+# security updates) and keep firing regardless of this file. To resume normal
+# cadence, restore each entry's previous limit (noted inline) and delete this
+# block.
+# =============================================================================
+
 updates:
   # ---------------------------------------------------------------------------
   # GitHub Actions — catches workflow action version drift.
@@ -16,7 +29,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0 # frozen; previous limit was 5
     labels:
       - dependencies
       - github-actions
@@ -37,7 +50,7 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0 # frozen; previous limit was 5
     labels:
       - dependencies
       - go
@@ -94,7 +107,7 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0 # frozen; previous limit was 3
     labels:
       - dependencies
       - frontend
@@ -113,7 +126,7 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0 # frozen; previous limit was 3
     labels:
       - dependencies
       - bazel

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Maintenance status
 
 Actively maintained until 2026-07-31. Paused after that date while the owner
-starts a new job; expected to resume around 2026-Q1/Q2. Security updates keep
+starts a new job; expected to resume around 2027-Q1/Q2. Security updates keep
 flowing during the pause — only version-update PRs are paused. Issues and PRs
 may not get a timely response in the meantime. The repo is left in a
 known-good state at the freeze point, not mid-refactor.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 ## Maintenance status
 
 Actively maintained until 2026-07-31. Paused after that date while the owner
-starts a new job; expected to resume around 2027-Q1/Q2. Security updates keep
-flowing during the pause — only version-update PRs are paused. Issues and PRs
-may not get a timely response in the meantime. The repo is left in a
-known-good state at the freeze point, not mid-refactor.
+starts a new job; expected to resume around 2027-Q1/Q2. Security updates still
+flow: Dependabot security updates are enabled on this repo (verified
+2026-07-31) and are not affected by the version-update limit below. Only
+version-update PRs are paused. Issues and PRs may not get a timely response
+in the meantime. The repo is left in a known-good state at the freeze point,
+not mid-refactor.
 
 <!-- session-close-review: status + narrative -->
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 [![CI](https://github.com/BinHsu/aegis-core/actions/workflows/ci-baseline.yml/badge.svg)](https://github.com/BinHsu/aegis-core/actions/workflows/ci-baseline.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/BinHsu/aegis-core/badge)](https://securityscorecards.dev/viewer/?uri=github.com/BinHsu/aegis-core)
 
+## Maintenance status
+
+Actively maintained until 2026-07-31. Paused after that date while the owner
+starts a new job; expected to resume around 2026-Q1/Q2. Security updates keep
+flowing during the pause — only version-update PRs are paused. Issues and PRs
+may not get a timely response in the meantime. The repo is left in a
+known-good state at the freeze point, not mid-refactor.
+
 <!-- session-close-review: status + narrative -->
 
 > **A chief-of-staff's tool for the moment before the principal speaks.**

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ## Maintenance status
 
-Actively maintained until 2026-07-31. Paused after that date while the owner
-starts a new job; expected to resume around 2027-Q1/Q2. Security updates still
-flow: Dependabot security updates are enabled on this repo (verified
-2026-07-31) and are not affected by the version-update limit below. Only
-version-update PRs are paused. Issues and PRs may not get a timely response
-in the meantime. The repo is left in a known-good state at the freeze point,
-not mid-refactor.
+Actively maintained through 2026-07-31. Paused from the merge of this change
+while the owner starts a new job; expected to resume around 2027-Q1/Q2.
+Security updates still flow: Dependabot security updates are enabled on this
+repo (verified 2026-07-31) and are not affected by the version-update limit
+below. Only version-update PRs are paused. Issues and PRs may not get a timely
+response in the meantime. The repo is left in a known-good state at the freeze
+point, not mid-refactor.
 
 <!-- session-close-review: status + narrative -->
 


### PR DESCRIPTION
## Summary

Two changes to prepare this repo for an extended unattended period —
the owner is starting a new job and won't be able to tend it for six
months or more.

- **`.github/dependabot.yml`**: set `open-pull-requests-limit: 0` on
  every version-update entry (previously 5/5/3/3). Dependabot stops
  opening version-update PRs, so they don't pile up unreviewed for
  months. **Security updates still flow** — Dependabot security updates
  are a separate repo setting (Settings → Code security → Dependabot
  security updates), not controlled by this file, and confirmed
  **enabled** on this repo via the GitHub API on 2026-07-31.
- **`README.md`**: added a `## Maintenance status` section right
  after the badges, before the rest of the body, so a visitor sees
  the freeze state immediately.

## Why

A public repo that quietly accumulates dozens of stale bot PRs over
a multi-month absence reads as abandoned. Turning the cadence down
deliberately, and saying so in the README, reads as intentional
instead.

## Test plan

- [x] python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" .github/dependabot.yml passes
- [x] No workflow, ruleset, or CI config touched
- [x] release-staging-frontend.yml untouched (already disabled via API)

https://claude.ai/code/session_01RNmWnfbEnSk5yBJe9TQBgn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a maintenance status section explaining the planned maintenance freeze beginning July 31, 2026.
  * Clarified that security updates will continue during the freeze.

* **Chores**
  * Paused automated version-update pull requests across supported dependency ecosystems during the maintenance freeze.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
